### PR TITLE
Log debug message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,10 @@ sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
 sea-query = { version = "^0.16.2" }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0", optional = true }
+log = { version = "^0.4", optional = true }
 
 [features]
-debug-print = []
+debug-print = [ "log" ]
 default = [ "mysql", "postgres", "discovery", "writer" ]
 mysql = []
 postgres = []

--- a/src/mysql/discovery/executor/mock.rs
+++ b/src/mysql/discovery/executor/mock.rs
@@ -21,7 +21,6 @@ impl Executor {
     pub async fn fetch_all(&self, select: SelectStatement) -> Vec<MySqlRow> {
         let (sql, values) = select.build(MysqlQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
-        debug_print!();
 
         panic!("This is a mock Executor");
     }

--- a/src/mysql/discovery/executor/real.rs
+++ b/src/mysql/discovery/executor/real.rs
@@ -24,7 +24,6 @@ impl Executor {
     pub async fn fetch_all(&self, select: SelectStatement) -> Vec<MySqlRow> {
         let (sql, values) = select.build(MysqlQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
-        debug_print!();
 
         let query = bind_query(sqlx::query(&sql), &values);
         query

--- a/src/mysql/discovery/mod.rs
+++ b/src/mysql/discovery/mod.rs
@@ -57,7 +57,6 @@ impl SchemaDiscovery {
             debug_print!("{:?}", result);
             let version = result.parse();
             debug_print!("{:?}", version);
-            debug_print!();
             return version;
         }
         panic!("failed to discover version")
@@ -80,7 +79,6 @@ impl SchemaDiscovery {
             })
             .collect();
 
-        debug_print!();
         tables
     }
 
@@ -131,7 +129,6 @@ impl SchemaDiscovery {
             })
             .collect::<Vec<_>>();
 
-        debug_print!();
         columns
     }
 
@@ -153,7 +150,6 @@ impl SchemaDiscovery {
                 return result;
             })
             .collect();
-        debug_print!();
 
         let indexes = parse_index_query_results(Box::new(results.into_iter()))
             .map(|index| {
@@ -161,7 +157,6 @@ impl SchemaDiscovery {
                 index
             })
             .collect::<Vec<_>>();
-        debug_print!();
 
         indexes
     }
@@ -184,7 +179,6 @@ impl SchemaDiscovery {
                 return result;
             })
             .collect();
-        debug_print!();
 
         let foreign_keys = parse_constraint_query_results(Box::new(results.into_iter()))
             .map(|index| {
@@ -192,7 +186,6 @@ impl SchemaDiscovery {
                 index
             })
             .collect::<Vec<_>>();
-        debug_print!();
 
         foreign_keys
     }

--- a/src/postgres/discovery/executor/mock.rs
+++ b/src/postgres/discovery/executor/mock.rs
@@ -21,7 +21,6 @@ impl Executor {
     pub async fn fetch_all(&self, select: SelectStatement) -> Vec<PgRow> {
         let (sql, values) = select.build(PostgresQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
-        debug_print!();
 
         panic!("This is a mock Executor");
     }

--- a/src/postgres/discovery/executor/real.rs
+++ b/src/postgres/discovery/executor/real.rs
@@ -24,7 +24,6 @@ impl Executor {
     pub async fn fetch_all(&self, select: SelectStatement) -> Vec<PgRow> {
         let (sql, values) = select.build(PostgresQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
-        debug_print!();
 
         let query = bind_query(sqlx::query(&sql), &values);
         query

--- a/src/postgres/discovery/mod.rs
+++ b/src/postgres/discovery/mod.rs
@@ -63,7 +63,6 @@ impl SchemaDiscovery {
             })
             .collect();
 
-        debug_print!();
         tables
     }
 
@@ -143,7 +142,6 @@ impl SchemaDiscovery {
             })
             .collect::<Vec<_>>();
 
-        debug_print!();
         columns
     }
 
@@ -168,7 +166,6 @@ impl SchemaDiscovery {
                 result
             })
             .collect();
-        debug_print!();
 
         let constraints = parse_table_constraint_query_results(Box::new(results.into_iter()))
             .map(|index| {
@@ -176,7 +173,6 @@ impl SchemaDiscovery {
                 index
             })
             .collect::<Vec<_>>();
-        debug_print!();
 
         constraints
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 #[cfg(feature = "debug-print")]
 macro_rules! debug_print {
-    ($( $args:expr ),*) => { println!( $( $args ),* ); }
+    ($( $args:expr ),*) => { log::debug!( $( $args ),* ); }
 }
 
 #[macro_export]


### PR DESCRIPTION
- Log debug message via `Log` crate instead of printing it out to stdout directly