### PR TITLE
Build docs.rs with `migration` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["database"]
 keywords = ["database", "sql", "mysql", "postgres"]
 
 [package.metadata.docs.rs]
-features = ["discovery"]
+features = ["default", "migration"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]


### PR DESCRIPTION
Currently the `migration` module is missing from docs.rs
https://docs.rs/sea-schema/0.5.0/sea_schema/index.html