### PR TITLE
Fix Sqlite BLOB type.

### DIFF
--- a/src/sqlite/types.rs
+++ b/src/sqlite/types.rs
@@ -105,7 +105,7 @@ impl Type {
                 column_def.string();
             }
             Self::Blob => {
-                column_def.custom(Alias::new("BLOB"));
+                column_def.binary();
             }
             Self::Real | Self::Double | Self::DoublePrecision | Self::Float | Self::Numeric => {
                 column_def.decimal();


### PR DESCRIPTION
Closes https://github.com/SeaQL/sea-orm/issues/490

Not entirely sure why it was done with an alias, but by changing the `ColumnType` to binary the following schema (when used with `sea-orm-cli`):

```sql
CREATE TABLE "Books"
(
    id             INTEGER                                  NOT NULL PRIMARY KEY AUTOINCREMENT,
    title          TEXT                                     NOT NULL,
    hash           BLOB                                     NOT NULL UNIQUE,
)
```

Used to produce:

```rust
#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
#[sea_orm(table_name = "Books")]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    pub title: String,
    #[sea_orm(column_type = "Custom(\"BLOB\".to_owned())")]
    pub hash: String,
}
```

And will now produce:

```rust
#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
#[sea_orm(table_name = "Books")]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    pub title: String,
    pub hash: Vec<u8>,
}
```