### PR TITLE
Migrate with `sea_orm::DbConn`

### DIFF
--- a/src/migration/manager.rs
+++ b/src/migration/manager.rs
@@ -4,17 +4,17 @@ use sea_orm::sea_query::{
     IndexDropStatement, Query, TableAlterStatement, TableCreateStatement, TableDropStatement,
     TableRenameStatement, TableTruncateStatement,
 };
-use sea_orm::{Condition, ConnectionTrait, DbBackend, DbErr, Statement, StatementBuilder};
+use sea_orm::{Condition, ConnectionTrait, DbBackend, DbConn, DbErr, Statement, StatementBuilder};
 
 use super::query_tables;
 
 /// Helper struct for writing migration scripts in migration file
 pub struct SchemaManager<'c> {
-    conn: &'c dyn ConnectionTrait,
+    conn: &'c DbConn,
 }
 
 impl<'c> SchemaManager<'c> {
-    pub fn new(conn: &'c dyn ConnectionTrait) -> Self {
+    pub fn new(conn: &'c DbConn) -> Self {
         Self { conn }
     }
 
@@ -30,7 +30,7 @@ impl<'c> SchemaManager<'c> {
         self.conn.get_database_backend()
     }
 
-    pub fn get_connection(&self) -> &'c dyn ConnectionTrait {
+    pub fn get_connection(&self) -> &'c DbConn {
         self.conn
     }
 }

--- a/tests/migration/src/lib.rs
+++ b/tests/migration/src/lib.rs
@@ -2,6 +2,7 @@ use sea_schema::migration::prelude::*;
 
 mod m20220118_000001_create_cake_table;
 mod m20220118_000002_create_fruit_table;
+mod m20220118_000003_seed_cake_table;
 
 pub struct Migrator;
 
@@ -11,6 +12,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20220118_000001_create_cake_table::Migration),
             Box::new(m20220118_000002_create_fruit_table::Migration),
+            Box::new(m20220118_000003_seed_cake_table::Migration),
         ]
     }
 }

--- a/tests/migration/src/m20220118_000003_seed_cake_table.rs
+++ b/tests/migration/src/m20220118_000003_seed_cake_table.rs
@@ -1,0 +1,52 @@
+use sea_orm::{entity::prelude::*, Set};
+use sea_schema::migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20220118_000003_seed_cake_table"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        cake::ActiveModel {
+            name: Set("Cheesecake".to_owned()),
+            ..Default::default()
+        }
+        .insert(db)
+        .await
+        .map(|_| ())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        cake::Entity::delete_many()
+            .filter(cake::Column::Name.eq("Cheesecake"))
+            .exec(db)
+            .await
+            .map(|_| ())
+    }
+}
+
+mod cake {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "cake")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        pub name: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}


### PR DESCRIPTION
## PR Info

- Closes SeaQL/sea-orm#522
- Related PR
  - SeaQL/sea-orm#523

## Breaking Changes

- `SchemaManager::get_connection` method returns `&'c DbConn`

## Changes

- `SchemaManager::conn` field is of type `&'c DbConn`
