### PR TITLE
Support Postgres jsonb in entity generation

### DIFF
--- a/src/postgres/def/types.rs
+++ b/src/postgres/def/types.rs
@@ -106,6 +106,8 @@ pub enum Type {
 
     /// JSON data checked for validity and with additional functions
     Json,
+    /// JSON data stored in a decomposed binary format that can be subscripted and used in indexes
+    JsonBinary,
 
     /// Variable-length multidimensional array
     Array,
@@ -186,6 +188,7 @@ impl Type {
             "uuid" => Type::Uuid,
             "xml" => Type::Xml,
             "json" => Type::Json,
+            "jsonb" => Type::JsonBinary,
             "array" => Type::Array,
             // "" => Type::Composite,
             "int4range" => Type::Int4Range,

--- a/src/postgres/writer/column.rs
+++ b/src/postgres/writer/column.rs
@@ -200,6 +200,9 @@ impl ColumnInfo {
             Type::Json => {
                 col_def.json();
             }
+            Type::JsonBinary => {
+                col_def.json_binary();
+            }
             Type::Array => {
                 col_def.custom(Alias::new("array"));
             }


### PR DESCRIPTION
## Fixes

`sea-orm-cli generate entity` currently treats Postgres `jsonb` columns as an unknown custom datatype, and gives its model field type `String`. It already supports `json` columns, and sea-query already supports `json_binary` in `ColumnDef`, so this just fills in the missing pieces to recognize `jsonb`.

## Breaking Changes

No breaking changes.

## Changes

No other changes.
