### PR TITLE
Bump sea-query and sea-orm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "^0.22.0" }
-sea-orm = { version = "^0.7.0", default-features = false, features = ["macros"], optional = true }
+sea-query = { version = "^0.24.0" }
+sea-orm = { version = "^0.7.1", default-features = false, features = ["macros"], optional = true }
 clap = { version = "^2.33.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 tracing = { version = "0.1", features = ["log"], optional = true }


### PR DESCRIPTION
## PR Info

Bump sea-query and sea-orm. 

I'm doing this because I want the on-conflict support that was recently added to sea-query

sea-orm [changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
sea-query [changelog](https://github.com/SeaQL/sea-query/blob/master/CHANGELOG.md)

I tested the version bumps and it didn't cause any issues on our project.

TODO:
- [ ] also bump crate in tests/migration/cargo.toml
- [ ] Merge sea-orm PR for on_conflict support (https://github.com/SeaQL/sea-orm/pull/671)