### PR TITLE
MySQL `blob` datatype maps to SeaQuery corresponding `blob` column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.9.0 - 2022-07-01
 
 * PostgreSQL datetime and timestamp datatype are equivalent #69
+* MySQL VarBinary column type mapping #67
 
 ## 0.8.1 - 2022-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.9.0 - 2022-07-01
+
+* PostgreSQL datetime and timestamp datatype are equivalent #69
+
 ## 0.8.1 - 2022-06-17
 
 * Fix SQLx version to ^0.5 https://github.com/SeaQL/sea-schema/pull/70

--- a/src/mysql/writer/column.rs
+++ b/src/mysql/writer/column.rs
@@ -1,5 +1,5 @@
 use crate::mysql::def::{CharSet, ColumnInfo, NumericAttr, StringAttr, Type};
-use sea_query::{escape_string, Alias, ColumnDef, Iden};
+use sea_query::{escape_string, Alias, BlobSize, ColumnDef, Iden};
 use std::fmt::Write;
 
 impl ColumnInfo {
@@ -211,21 +211,20 @@ impl ColumnInfo {
                 // FIXME: Unresolved type mapping
                 col_def.custom(self.col_type.clone());
             }
-            Type::Blob(_) => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+            Type::Blob(blob_attr) => {
+                match blob_attr.length {
+                    Some(length) => col_def.binary_len(length),
+                    None => col_def.binary(),
+                };
             }
             Type::TinyBlob => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+                col_def.blob(BlobSize::Tiny);
             }
             Type::MediumBlob => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+                col_def.blob(BlobSize::Medium);
             }
             Type::LongBlob => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+                col_def.blob(BlobSize::Long);
             }
             Type::Enum(enum_attr) => {
                 col_def.enumeration(&self.name, &enum_attr.values);


### PR DESCRIPTION
## PR Info

- Closes SeaQL/sea-orm#684

- Dependencies:
  - SeaQL/sea-query#314

- Dependents:
  - SeaQL/sea-orm#685

## Fixes

- MySQL tables with `blob` column maps to corresponding `blob` column types in SeaQuery