### PR TITLE
Explicitly choose database type and TLS lib for `migration`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,13 @@ migration = [
     "tracing",
     "dotenv",
     "debug-print",
-    # eable all connection discover
-    "sea-orm/sqlx-all",
-    # enable sqlx run time 
-    "runtime-async-std-native-tls"
 ]
+migration-mysql = ["sea-orm/sqlx-mysql"]
+migration-postgres = ["sea-orm/sqlx-postgres"]
+migration-sqlite = ["sea-orm/sqlx-sqlite"]
+migration-all = ["sea-orm/sqlx-all"]
+migration-native-tls = ["runtime-async-std-native-tls"]
+migration-rustls = ["runtime-async-std-rustls"]
 query = ["def"]
 writer = ["def"]
 sqlx-dep = ["sqlx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 [package]
 name = "sea-schema"
 version = "0.7.1"
-authors = [ "Chris Tsang <tyt2y7@gmail.com>" ]
+authors = ["Chris Tsang <tyt2y7@gmail.com>"]
 edition = "2021"
 description = "🌿 SQL schema definition and discovery"
 license = "MIT OR Apache-2.0"
@@ -37,13 +37,20 @@ path = "src/lib.rs"
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
 sea-query = { version = "^0.22.0" }
-sea-orm = { version = "^0.7.0", default-features = false, features = ["macros"], optional = true }
+sea-orm = { version = "^0.7.0", default-features = false, features = [
+    "macros"
+], optional = true }
 clap = { version = "^2.33.3", optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter"
+], optional = true }
 tracing = { version = "0.1", features = ["log"], optional = true }
 dotenv = { version = "^0.15", optional = true }
 async-trait = { version = "^0.1", optional = true }
-async-std = { version = "^1", features = [ "attributes", "tokio1" ], optional = true }
+async-std = { version = "^1", features = [
+    "attributes",
+    "tokio1"
+], optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0", optional = true }
 log = { version = "^0.4", optional = true }
@@ -57,7 +64,20 @@ sqlite = []
 def = []
 discovery = ["futures", "parser"]
 parser = ["query"]
-migration = [ "async-trait", "async-std", "sea-orm", "clap", "tracing-subscriber", "tracing", "dotenv", "debug-print" ]
+migration = [
+    "async-trait",
+    "async-std",
+    "sea-orm",
+    "clap",
+    "tracing-subscriber",
+    "tracing",
+    "dotenv",
+    "debug-print",
+    # eable all connection discover
+    "sea-orm/sqlx-all",
+    # enable sqlx run time 
+    "runtime-async-std-native-tls"
+]
 query = ["def"]
 writer = ["def"]
 sqlx-dep = ["sqlx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,20 +37,13 @@ path = "src/lib.rs"
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
 sea-query = { version = "^0.22.0" }
-sea-orm = { version = "^0.7.0", default-features = false, features = [
-    "macros"
-], optional = true }
+sea-orm = { version = "^0.7.0", default-features = false, features = ["macros"], optional = true }
 clap = { version = "^2.33.3", optional = true }
-tracing-subscriber = { version = "0.3", features = [
-    "env-filter"
-], optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 tracing = { version = "0.1", features = ["log"], optional = true }
 dotenv = { version = "^0.15", optional = true }
 async-trait = { version = "^0.1", optional = true }
-async-std = { version = "^1", features = [
-    "attributes",
-    "tokio1"
-], optional = true }
+async-std = { version = "^1", features = ["attributes", "tokio1"], optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0", optional = true }
 log = { version = "^0.4", optional = true }
@@ -64,16 +57,7 @@ sqlite = []
 def = []
 discovery = ["futures", "parser"]
 parser = ["query"]
-migration = [
-    "async-trait",
-    "async-std",
-    "sea-orm",
-    "clap",
-    "tracing-subscriber",
-    "tracing",
-    "dotenv",
-    "debug-print",
-]
+migration = ["async-trait", "async-std", "sea-orm", "clap", "tracing-subscriber", "tracing", "dotenv", "debug-print",]
 migration-mysql = ["sea-orm/sqlx-mysql"]
 migration-postgres = ["sea-orm/sqlx-postgres"]
 migration-sqlite = ["sea-orm/sqlx-sqlite"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 [package]
 name = "sea-schema"
 version = "0.7.1"
-authors = ["Chris Tsang <tyt2y7@gmail.com>"]
+authors = [ "Chris Tsang <tyt2y7@gmail.com>" ]
 edition = "2021"
 description = "🌿 SQL schema definition and discovery"
 license = "MIT OR Apache-2.0"
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 tracing = { version = "0.1", features = ["log"], optional = true }
 dotenv = { version = "^0.15", optional = true }
 async-trait = { version = "^0.1", optional = true }
-async-std = { version = "^1", features = ["attributes", "tokio1"], optional = true }
+async-std = { version = "^1", features = [ "attributes", "tokio1" ], optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0", optional = true }
 log = { version = "^0.4", optional = true }
@@ -57,7 +57,7 @@ sqlite = []
 def = []
 discovery = ["futures", "parser"]
 parser = ["query"]
-migration = ["async-trait", "async-std", "sea-orm", "clap", "tracing-subscriber", "tracing", "dotenv", "debug-print",]
+migration = [ "async-trait", "async-std", "sea-orm", "clap", "tracing-subscriber", "tracing", "dotenv", "debug-print" ]
 migration-mysql = ["sea-orm/sqlx-mysql"]
 migration-postgres = ["sea-orm/sqlx-postgres"]
 migration-sqlite = ["sea-orm/sqlx-sqlite"]


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- https://github.com/SeaQL/sea-orm/issues/688#issue-1218191492

### TODO

- [x] adding feature flags

## Adds

Adding a group of feature flags like  `migration_*`. to explicit choice whitch SQL database and TLS lib  to use

## Changes

adding follow feature flags
```toml
migration-mysql = ["sea-orm/sqlx-mysql"]
migration-postgres = ["sea-orm/sqlx-postgres"]
migration-sqlite = ["sea-orm/sqlx-sqlite"]
migration-all = ["sea-orm/sqlx-all"]
# migration has it own runtime `async-std` , only need select tls lib
migration-native-tls = ["runtime-async-std-native-tls"]
migration-rustls = ["runtime-async-std-rustls"]
```

I just edit `Cargo.toml` to enable user having a explicit way to select Database Type Using and TLS lib, instead of adding dependece `entity` to enable `sea-orm` feature flage implicit

Maybe I need provide an example?
