### PR TITLE
PostgreSQL query non-key foreign key info

### DIFF
--- a/src/postgres/query/constraints/mod.rs
+++ b/src/postgres/query/constraints/mod.rs
@@ -144,14 +144,14 @@ impl SchemaQueryBuilder {
                         (Schema::ReferentialConstraints, RefC::DeleteRule),
                     ])
                     .columns(vec![
-                        (Schema::KeyColumnUsage, Kcuf::TableName),
-                        (Schema::KeyColumnUsage, Kcuf::ColumnName),
+                        (Schema::ConstraintColumnUsage, Kcuf::TableName),
+                        (Schema::ConstraintColumnUsage, Kcuf::ColumnName),
                     ])
                     .from((Schema::Schema, Schema::ReferentialConstraints))
                     .left_join(
-                        (Schema::Schema, Schema::KeyColumnUsage),
-                        Expr::tbl(Schema::ReferentialConstraints, RefC::UniqueConstraintName)
-                            .equals(Schema::KeyColumnUsage, Kcuf::ConstraintName),
+                        (Schema::Schema, Schema::ConstraintColumnUsage),
+                        Expr::tbl(Schema::ReferentialConstraints, RefC::ConstraintName)
+                            .equals(Schema::ConstraintColumnUsage, Kcuf::ConstraintName),
                     )
                     .take(),
                 rcsq.clone(),

--- a/src/postgres/query/schema.rs
+++ b/src/postgres/query/schema.rs
@@ -12,4 +12,5 @@ pub enum InformationSchema {
     ReferentialConstraints,
     Tables,
     TableConstraints,
+    ConstraintColumnUsage,
 }


### PR DESCRIPTION
## PR Info

- Closes SeaQL/sea-orm#699

## Fixes

- [x] Fetching info of PostgreSQL's foreign key referencing table and column from `constraint_column_usage` information schema
  - https://www.postgresql.org/docs/current/infoschema-constraint-column-usage.html