### PR TITLE
MySQL `VarBinary` column type mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "^0.24.0" }
+sea-query = { version = "^0.24.0", git = "https://github.com/SeaQL/sea-query", branch = "var-binary" }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0", optional = true }
 log = { version = "^0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "^0.24.0", git = "https://github.com/SeaQL/sea-query", branch = "var-binary" }
+sea-query = { version = "^0.25.0" }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0", optional = true }
 log = { version = "^0.4", optional = true }

--- a/src/mysql/writer/column.rs
+++ b/src/mysql/writer/column.rs
@@ -189,9 +189,11 @@ impl ColumnInfo {
                 };
                 col_def = self.write_str_attr(col_def, str_attr);
             }
-            Type::Varbinary(_) => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+            Type::Varbinary(str_attr) => {
+                match str_attr.length {
+                    Some(length) => col_def.var_binary(length),
+                    None => col_def.binary(),
+                };
             }
             Type::Text(str_attr) => {
                 col_def.text();


### PR DESCRIPTION
## PR Info

- Closes SeaQL/sea-orm#704

- Dependencies:
  - SeaQL/sea-query#331

## Adds

- [x] Map MySQL `VarBinary` datatype to the newly added column type in SeaQuery
