### PR TITLE
PostgreSQL datetime and timestamp datatype are equivalent

### DIFF
--- a/src/postgres/writer/column.rs
+++ b/src/postgres/writer/column.rs
@@ -103,9 +103,11 @@ impl ColumnInfo {
                 col_def.binary();
             }
             Type::Timestamp(time_attr) => {
+                // The SQL standard requires that writing just timestamp be equivalent to timestamp without time zone,
+                // and PostgreSQL honors that behavior. (https://www.postgresql.org/docs/current/datatype-datetime.html)
                 match time_attr.precision {
-                    Some(precision) => col_def.timestamp_len(precision.into()),
-                    None => col_def.timestamp(),
+                    Some(precision) => col_def.date_time_len(precision.into()),
+                    None => col_def.date_time(),
                 };
             }
             Type::TimestampWithTimeZone(time_attr) => {

--- a/tests/live/postgres/src/main.rs
+++ b/tests/live/postgres/src/main.rs
@@ -207,7 +207,7 @@ fn create_order_table() -> TableCreateStatement {
         )
         .col(
             ColumnDef::new(Alias::new("placed_at"))
-                .timestamp_len(6)
+                .date_time_len(6)
                 .not_null(),
         )
         .primary_key(


### PR DESCRIPTION
## PR Info

- Closes SeaQL/sea-orm#586

## Breaking Changes

- [x] Timestamp datatype in PostgreSQL now maps to `ColumnType::DateTime` in SeaQuery

> The SQL standard requires that writing just timestamp be equivalent to timestamp without time zone, and PostgreSQL honors that behavior.
> _https://www.postgresql.org/docs/current/datatype-datetime.html_