### PR TITLE
Fix SQLx version to ^0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
 sea-query = { version = "^0.24.0" }
 serde = { version = "^1", features = ["derive"], optional = true }
-sqlx = { version = "^0", optional = true }
+sqlx = { version = "^0.5", optional = true }
 log = { version = "^0.4", optional = true }
 
 [features]

--- a/tests/discovery/mysql/Cargo.toml
+++ b/tests/discovery/mysql/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/discovery/postgres/Cargo.toml
+++ b/tests/discovery/postgres/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/discovery/sqlite/Cargo.toml
+++ b/tests/discovery/sqlite/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }

--- a/tests/live/mysql/Cargo.toml
+++ b/tests/live/mysql/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }
 pretty_assertions = { version = "^0.7" }
 regex = { version = "^1" }
 env_logger = { version = "^0" }

--- a/tests/live/postgres/Cargo.toml
+++ b/tests/live/postgres/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/live/sqlite/Cargo.toml
+++ b/tests/live/sqlite/Cargo.toml
@@ -17,7 +17,7 @@ sea-schema = { path = "../../../", default-features = false, features = [
     "sqlite",
 ] }
 serde_json = { version = "^1" }
-sqlx = { version = "0.5.9", features = [
+sqlx = { version = "^0.5", features = [
     "sqlite",
     "runtime-async-std-native-tls",
 ] }

--- a/tests/writer/mysql/Cargo.toml
+++ b/tests/writer/mysql/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/writer/postgres/Cargo.toml
+++ b/tests/writer/postgres/Cargo.toml
@@ -9,6 +9,6 @@ pretty_assertions = { version = "^0.7" }
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/writer/sqlite/Cargo.toml
+++ b/tests/writer/sqlite/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0" }
+sqlx = { version = "^0.5" }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/797

## Fixes

- [ ] Fixing SQLx version to ^0.5 instead of ^0