### PR TITLE
Bump sqlx version in test cases

### DIFF
--- a/tests/discovery/mysql/Cargo.toml
+++ b/tests/discovery/mysql/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0.5" }
+sqlx = { version = "^0.6" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/discovery/postgres/Cargo.toml
+++ b/tests/discovery/postgres/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0.5" }
+sqlx = { version = "^0.6" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/discovery/sqlite/Cargo.toml
+++ b/tests/discovery/sqlite/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0.5" }
+sqlx = { version = "^0.6" }

--- a/tests/writer/mysql/Cargo.toml
+++ b/tests/writer/mysql/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0.5" }
+sqlx = { version = "^0.6" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/writer/postgres/Cargo.toml
+++ b/tests/writer/postgres/Cargo.toml
@@ -9,6 +9,6 @@ pretty_assertions = { version = "^0.7" }
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0.5" }
+sqlx = { version = "^0.6" }
 env_logger = { version = "^0" }
 log = { version = "^0" }

--- a/tests/writer/sqlite/Cargo.toml
+++ b/tests/writer/sqlite/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "^1" }
-sqlx = { version = "^0.5" }
+sqlx = { version = "^0.6" }


### PR DESCRIPTION
## Fixes

- [x] Bump sqlx version to 0.6 to match the sqlx version used by SeaSchema