### PR TITLE
Fixup - custom function without expressions has to include parentheses

### DIFF
--- a/src/mysql/query/version.rs
+++ b/src/mysql/query/version.rs
@@ -4,6 +4,7 @@ use sea_query::{Func, Query, SelectStatement};
 
 #[derive(sea_query::Iden)]
 enum MysqlFunc {
+    #[iden = "version()"]
     Version,
 }
 


### PR DESCRIPTION
## Fixes

- [x] MySQL: select MySQL version with `SELECT version()` become `SELECT version` due to breaking changes introduced by SeaQuery 0.26