### PR TITLE
SQLite real datatype maps to double

### DIFF
--- a/src/sqlite/def/types.rs
+++ b/src/sqlite/def/types.rs
@@ -108,7 +108,7 @@ impl Type {
                 column_def.binary();
             }
             Self::Real | Self::Double | Self::DoublePrecision | Self::Float | Self::Numeric => {
-                column_def.decimal();
+                column_def.double();
             }
             Self::Decimal {
                 integral,


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/637

## Fixes

- [x] SQLite: real, double, float datatype should maps to double in SeaQuery instead of decimal