### PR TITLE
PostgreSQL & CockroachDB compatible schema discovery

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -380,6 +380,65 @@ jobs:
           args: >
             --manifest-path tests/${{ matrix.project }}/Cargo.toml
 
+  cockroachdb:
+    name: CockroachDB
+    needs: compile-postgres
+    runs-on: ubuntu-20.04
+    env:
+      DATABASE_URL_SAKILA: "postgres://root@localhost:26257/sakila"
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [latest_21_2]
+        project: [discovery/postgres, writer/postgres]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            Cargo.lock
+            target
+          key: ${{ github.sha }}-${{ github.run_id }}-${{ runner.os }}-postgres-${{ matrix.project }}
+
+      - name: Setup CockroachDB
+        run: docker-compose -f build-tools/docker-compose.yml up -d cockroachdb_${{ matrix.version }}
+
+      - name: Wait CockroachDB ready
+        run: sleep 15s
+        shell: bash
+
+      - name: Create DB
+        run: psql -q postgres://root@localhost:26257/postgres -c 'CREATE DATABASE "sakila"'
+
+      - name: Import DB Schema
+        run: psql -q postgres://root@localhost:26257/sakila < sakila-schema.sql
+        working-directory: ./tests/sakila/postgres
+
+      - name: Import DB Data
+        run: psql -q postgres://root@localhost:26257/sakila < sakila-data.sql
+        working-directory: ./tests/sakila/postgres
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: >
+            --manifest-path tests/${{ matrix.project }}/Cargo.toml
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            --manifest-path tests/${{ matrix.project }}/Cargo.toml
+
   sqlite:
     name: SQLite
     needs: compile-sqlite

--- a/build-tools/docker-compose.yml
+++ b/build-tools/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.2"
+
+services:
+
+    cockroachdb_latest_21_2:
+        image: cockroachdb/cockroach:latest-v21.2
+        command: [ start-single-node, --insecure ]
+        ports: [ 8080:8080, 26257:26257 ]

--- a/src/postgres/def/table.rs
+++ b/src/postgres/def/table.rs
@@ -1,4 +1,3 @@
-use super::*;
 #[cfg(feature = "with-serde")]
 use serde::{Deserialize, Serialize};
 
@@ -8,7 +7,6 @@ use serde::{Deserialize, Serialize};
 /// table including its columns and constraints, use [`TableDef`]
 pub struct TableInfo {
     pub name: String,
-    pub of_type: Option<Type>,
     // TODO:
     // pub comment: String
 }

--- a/src/postgres/parser/column.rs
+++ b/src/postgres/parser/column.rs
@@ -49,9 +49,9 @@ pub fn parse_column_type(result: &ColumnQueryResult) -> ColumnType {
 }
 
 pub fn parse_numeric_attributes(
-    num_precision: Option<i32>,
-    num_precision_radix: Option<i32>,
-    num_scale: Option<i32>,
+    num_precision: Option<i64>,
+    num_precision_radix: Option<i64>,
+    num_scale: Option<i64>,
     mut ctype: ColumnType,
 ) -> ColumnType {
     let numeric_precision: Option<u16> = match num_precision {
@@ -88,7 +88,7 @@ pub fn parse_numeric_attributes(
 }
 
 pub fn parse_string_attributes(
-    character_maximum_length: Option<i32>,
+    character_maximum_length: Option<i64>,
     mut ctype: ColumnType,
 ) -> ColumnType {
     match ctype {
@@ -107,7 +107,7 @@ pub fn parse_string_attributes(
     ctype
 }
 
-pub fn parse_time_attributes(datetime_precision: Option<i32>, mut ctype: ColumnType) -> ColumnType {
+pub fn parse_time_attributes(datetime_precision: Option<i64>, mut ctype: ColumnType) -> ColumnType {
     match ctype {
         Type::Timestamp(ref mut attr)
         | Type::TimestampWithTimeZone(ref mut attr)
@@ -129,7 +129,7 @@ pub fn parse_time_attributes(datetime_precision: Option<i32>, mut ctype: ColumnT
 
 pub fn parse_interval_attributes(
     interval_type: &Option<String>,
-    interval_precision: Option<i32>,
+    interval_precision: Option<i64>,
     mut ctype: ColumnType,
 ) -> ColumnType {
     match ctype {
@@ -150,7 +150,7 @@ pub fn parse_interval_attributes(
 }
 
 pub fn parse_bit_attributes(
-    character_maximum_length: Option<i32>,
+    character_maximum_length: Option<i64>,
     mut ctype: ColumnType,
 ) -> ColumnType {
     match ctype {

--- a/src/postgres/parser/table.rs
+++ b/src/postgres/parser/table.rs
@@ -10,8 +10,5 @@ impl TableQueryResult {
 pub fn parse_table_query_result(table_query: TableQueryResult) -> TableInfo {
     TableInfo {
         name: table_query.table_name,
-        of_type: table_query
-            .user_defined_type_name
-            .map(|type_name| Type::from_str(&type_name)),
     }
 }

--- a/src/postgres/query/mod.rs
+++ b/src/postgres/query/mod.rs
@@ -1,3 +1,5 @@
+use sea_query::{Alias, IntoColumnRef, SimpleExpr};
+
 pub mod char_set;
 pub mod column;
 pub mod constraints;
@@ -11,3 +13,13 @@ pub use constraints::*;
 pub use enumeration::*;
 pub use schema::*;
 pub use table::*;
+
+pub(crate) fn cast_cols_as_int8<T, I>(cols: I) -> Vec<SimpleExpr>
+where
+    T: IntoColumnRef,
+    I: IntoIterator<Item = T>,
+{
+    cols.into_iter()
+        .map(|col| SimpleExpr::Column(col.into_column_ref()).cast_as(Alias::new("INT8")))
+        .collect()
+}

--- a/src/postgres/query/table.rs
+++ b/src/postgres/query/table.rs
@@ -31,18 +31,12 @@ pub enum TableType {
 #[derive(Debug, Default)]
 pub struct TableQueryResult {
     pub table_name: String,
-    pub user_defined_type_schema: Option<String>,
-    pub user_defined_type_name: Option<String>,
 }
 
 impl SchemaQueryBuilder {
     pub fn query_tables(&self, schema: SeaRc<dyn Iden>) -> SelectStatement {
         Query::select()
-            .columns(vec![
-                TablesFields::TableName,
-                TablesFields::UserDefinedTypeSchema,
-                TablesFields::UserDefinedTypeName,
-            ])
+            .column(TablesFields::TableName)
             .from((InformationSchema::Schema, InformationSchema::Tables))
             .and_where(Expr::col(TablesFields::TableSchema).eq(schema.to_string()))
             .and_where(Expr::col(TablesFields::TableType).eq(TableType::BaseTable.to_string()))
@@ -56,8 +50,6 @@ impl From<&PgRow> for TableQueryResult {
         use crate::sqlx_types::Row;
         Self {
             table_name: row.get(0),
-            user_defined_type_schema: row.get(1),
-            user_defined_type_name: row.get(2),
         }
     }
 }

--- a/tests/discovery/postgres/schema.rs
+++ b/tests/discovery/postgres/schema.rs
@@ -4,7 +4,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "actor",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -108,7 +107,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "film",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -373,7 +371,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment_p2007_02",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -545,7 +542,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment_p2007_03",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -717,7 +713,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment_p2007_04",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -889,7 +884,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment_p2007_05",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1061,7 +1055,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment_p2007_06",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1233,7 +1226,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment_p2007_01",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1405,7 +1397,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "address",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1586,7 +1577,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "category",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1670,7 +1660,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "city",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1785,7 +1774,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "country",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -1869,7 +1857,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "customer",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2083,7 +2070,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "film_actor",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2191,7 +2177,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "film_category",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2299,7 +2284,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "inventory",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2424,7 +2408,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "language",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2508,7 +2491,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "rental",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2696,7 +2678,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "staff",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -2932,7 +2913,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "store",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {
@@ -3057,7 +3037,6 @@ Schema {
         TableDef {
             info: TableInfo {
                 name: "payment",
-                of_type: None,
             },
             columns: [
                 ColumnInfo {


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-schema/issues/78

## Breaking Changes

- [x] `TableInfo::of_type`, `TableQueryResult::user_defined_type_schema`, `TableQueryResult::user_defined_type_name` have been dropped. Because it's not compatible with the information schema of CockroachDB. And, I think it's rarely used.
- [x] Numeric / precision fields' type are changed from `i32` to `i64`

## Changes

- [x] Numeric / precision fields are casted into `INT8` when selecting from the information schema. The reason being the corresponding fields in the PostgreSQL is `INT4` but in CockroachDB it's `INT8`. To make it compatible for both db engine, I perform an explicit cast into `INT8`.
