### PR TITLE
Fix parsing of Postgres user-defined types

### DIFF
--- a/src/postgres/query/column.rs
+++ b/src/postgres/query/column.rs
@@ -66,6 +66,7 @@ pub struct ColumnQueryResult {
     pub interval_precision: Option<i32>,
 
     pub udt_name: Option<String>,
+    pub udt_name_regtype: Option<String>,
 }
 
 impl SchemaQueryBuilder {
@@ -75,12 +76,9 @@ impl SchemaQueryBuilder {
         table: SeaRc<dyn Iden>,
     ) -> SelectStatement {
         Query::select()
-            .column(ColumnsField::ColumnName)
-            .expr(
-                Expr::expr(Expr::cust("udt_name::regtype").cast_as(Alias::new("text")))
-                    .binary(BinOper::As, Expr::col(ColumnsField::DataType)),
-            )
             .columns([
+                ColumnsField::ColumnName,
+                ColumnsField::DataType,
                 ColumnsField::ColumnDefault,
                 ColumnsField::GenerationExpression,
                 ColumnsField::IsNullable,
@@ -95,6 +93,10 @@ impl SchemaQueryBuilder {
                 ColumnsField::IntervalPrecision,
                 ColumnsField::UdtName,
             ])
+            .expr(
+                Expr::expr(Expr::cust("udt_name::regtype").cast_as(Alias::new("text")))
+                    .binary(BinOper::As, Expr::col(Alias::new("udt_name_regtype"))),
+            )
             .from((InformationSchema::Schema, InformationSchema::Columns))
             .and_where(Expr::col(ColumnsField::TableSchema).eq(schema.to_string()))
             .and_where(Expr::col(ColumnsField::TableName).eq(table.to_string()))
@@ -122,6 +124,7 @@ impl From<&PgRow> for ColumnQueryResult {
             interval_type: row.get(12),
             interval_precision: row.get(13),
             udt_name: row.get(14),
+            udt_name_regtype: row.get(15),
         }
     }
 }

--- a/src/postgres/writer/column.rs
+++ b/src/postgres/writer/column.rs
@@ -146,9 +146,9 @@ impl ColumnInfo {
                         .collect();
                     ColumnType::Enum { name, variants }
                 }
-                Type::Array(col_type) => {
-                    ColumnType::Array(SeaRc::new(Box::new(write_type(col_type))))
-                }
+                Type::Array(array_def) => ColumnType::Array(SeaRc::new(Box::new(write_type(
+                    array_def.col_type.as_ref().expect("Array type not defined"),
+                )))),
             }
         }
         write_type(&self.col_type)


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/1153

## Fixes

- [x] An edge case where `data_type` column equals to `USER-DEFINED` is being overlooked, this makes Enum column will be treated as `Type::Unknown`