### PR TITLE
SeaQuery 0.28.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ path = "src/lib.rs"
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
 sea-query = { version = "^0.28.0", git = "https://github.com/SeaQL/sea-query" }
-sea-query-binder = { version = "^0.2", optional = true  }
+sea-query-binder = { version = "^0.2", optional = true, git = "https://github.com/SeaQL/sea-query" }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0.6", optional = true }
 log = { version = "^0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "^0.28.0", git = "https://github.com/SeaQL/sea-query" }
-sea-query-binder = { version = "^0.2", optional = true, git = "https://github.com/SeaQL/sea-query" }
+sea-query = { version = "^0.28.0" }
+sea-query-binder = { version = "^0.3", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0.6", optional = true }
 log = { version = "^0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "^0.27.1" }
+sea-query = { version = "^0.28.0", git = "https://github.com/SeaQL/sea-query" }
 sea-query-binder = { version = "^0.2", optional = true  }
 serde = { version = "^1", features = ["derive"], optional = true }
 sqlx = { version = "^0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ documentation = "https://docs.rs/sea-schema"
 repository = "https://github.com/SeaQL/sea-schema"
 categories = ["database"]
 keywords = ["database", "sql", "mysql", "postgres"]
+rust-version = "1.62"
 
 [package.metadata.docs.rs]
 features = ["default"]

--- a/src/mysql/probe.rs
+++ b/src/mysql/probe.rs
@@ -16,7 +16,7 @@ impl SchemaProbe for MySql {
             .cond_where(
                 Condition::all().add(
                     Expr::expr(Self::get_current_schema())
-                        .equals(Schema::Tables, TablesFields::TableSchema),
+                        .equals((Schema::Tables, TablesFields::TableSchema)),
                 ),
             )
             .take()

--- a/src/mysql/query/foreign_key.rs
+++ b/src/mysql/query/foreign_key.rs
@@ -64,10 +64,10 @@ impl SchemaQueryBuilder {
             .inner_join(
                 (Schema::Schema, Schema::ReferentialConstraints),
                 Expr::tbl(Schema::KeyColumnUsage, Key::ConstraintSchema)
-                    .equals(Schema::ReferentialConstraints, Ref::ConstraintSchema)
+                    .equals((Schema::ReferentialConstraints, Ref::ConstraintSchema))
                     .and(
                         Expr::tbl(Schema::KeyColumnUsage, Key::ConstraintName)
-                            .equals(Schema::ReferentialConstraints, Ref::ConstraintName),
+                            .equals((Schema::ReferentialConstraints, Ref::ConstraintName)),
                     ),
             )
             .and_where(

--- a/src/mysql/query/table.rs
+++ b/src/mysql/query/table.rs
@@ -73,7 +73,7 @@ impl SchemaQueryBuilder {
                     Schema::CollationCharacterSet,
                     CharacterSetFields::CollationName,
                 )
-                .equals(Schema::Tables, TablesFields::TableCollation),
+                .equals((Schema::Tables, TablesFields::TableCollation)),
             )
             .and_where(Expr::col(TablesFields::TableSchema).eq(schema.to_string()))
             .and_where(Expr::col(TablesFields::TableType).is_in([

--- a/src/mysql/query/version.rs
+++ b/src/mysql/query/version.rs
@@ -14,9 +14,7 @@ pub struct VersionQueryResult {
 
 impl SchemaQueryBuilder {
     pub fn query_version(&self) -> SelectStatement {
-        Query::select()
-            .expr(Func::cust(MysqlFunc::Version).into_simple_expr())
-            .take()
+        Query::select().expr(Func::cust(MysqlFunc::Version)).take()
     }
 }
 

--- a/src/mysql/writer/column.rs
+++ b/src/mysql/writer/column.rs
@@ -102,13 +102,13 @@ impl ColumnInfo {
             Type::Date => {
                 col_def.date();
             }
-            Type::Time(time_attr) => {
+            Type::Time(_) => {
                 col_def.time();
             }
-            Type::DateTime(time_attr) => {
+            Type::DateTime(_) => {
                 col_def.date_time();
             }
-            Type::Timestamp(time_attr) => {
+            Type::Timestamp(_) => {
                 col_def.timestamp();
             }
             Type::Year => {

--- a/src/mysql/writer/column.rs
+++ b/src/mysql/writer/column.rs
@@ -53,34 +53,20 @@ impl ColumnInfo {
                 col_def.custom(self.col_type.clone());
             }
             Type::TinyInt(num_attr) => {
-                if num_attr.unsigned.is_some() {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.tiny_unsigned_len(maximum),
-                        None => col_def.tiny_unsigned(),
-                    };
-                } else {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.tiny_integer_len(maximum),
-                        None => col_def.tiny_integer(),
-                    };
-                }
+                match num_attr.unsigned {
+                    Some(_) => col_def.tiny_unsigned(),
+                    None => col_def.tiny_integer(),
+                };
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Bool => {
                 col_def.boolean();
             }
             Type::SmallInt(num_attr) => {
-                if num_attr.unsigned.is_some() {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.small_unsigned_len(maximum),
-                        None => col_def.small_unsigned(),
-                    };
-                } else {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.small_integer_len(maximum),
-                        None => col_def.small_integer(),
-                    };
-                }
+                match num_attr.unsigned {
+                    Some(_) => col_def.small_unsigned(),
+                    None => col_def.small_integer(),
+                };
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::MediumInt(_) => {
@@ -88,74 +74,42 @@ impl ColumnInfo {
                 col_def.custom(self.col_type.clone());
             }
             Type::Int(num_attr) => {
-                if num_attr.unsigned.is_some() {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.unsigned_len(maximum),
-                        None => col_def.unsigned(),
-                    };
-                } else {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.integer_len(maximum),
-                        None => col_def.integer(),
-                    };
-                }
+                match num_attr.unsigned {
+                    Some(_) => col_def.unsigned(),
+                    None => col_def.integer(),
+                };
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::BigInt(num_attr) => {
-                if num_attr.unsigned.is_some() {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.big_unsigned_len(maximum),
-                        None => col_def.big_unsigned(),
-                    };
-                } else {
-                    match num_attr.maximum {
-                        Some(maximum) => col_def.big_integer_len(maximum),
-                        None => col_def.big_integer(),
-                    };
-                }
+                match num_attr.unsigned {
+                    Some(_) => col_def.big_unsigned(),
+                    None => col_def.big_integer(),
+                };
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Decimal(num_attr) => {
-                match (num_attr.maximum, num_attr.decimal) {
-                    (Some(maximum), Some(decimal)) => col_def.decimal_len(maximum, decimal),
-                    _ => col_def.decimal(),
-                };
+                col_def.decimal();
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Float(num_attr) => {
-                match num_attr.decimal {
-                    Some(decimal) => col_def.float_len(decimal),
-                    _ => col_def.float(),
-                };
+                col_def.float();
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Double(num_attr) => {
-                match num_attr.decimal {
-                    Some(decimal) => col_def.double_len(decimal),
-                    _ => col_def.double(),
-                };
+                col_def.double();
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Date => {
                 col_def.date();
             }
             Type::Time(time_attr) => {
-                match time_attr.fractional {
-                    Some(fractional) => col_def.time_len(fractional),
-                    _ => col_def.time(),
-                };
+                col_def.time();
             }
             Type::DateTime(time_attr) => {
-                match time_attr.fractional {
-                    Some(fractional) => col_def.date_time_len(fractional),
-                    _ => col_def.date_time(),
-                };
+                col_def.date_time();
             }
             Type::Timestamp(time_attr) => {
-                match time_attr.fractional {
-                    Some(fractional) => col_def.timestamp_len(fractional),
-                    _ => col_def.timestamp(),
-                };
+                col_def.timestamp();
             }
             Type::Year => {
                 // FIXME: Unresolved type mapping

--- a/src/mysql/writer/column.rs
+++ b/src/mysql/writer/column.rs
@@ -88,7 +88,10 @@ impl ColumnInfo {
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Decimal(num_attr) => {
-                col_def.decimal();
+                match (num_attr.maximum, num_attr.decimal) {
+                    (Some(maximum), Some(decimal)) => col_def.decimal_len(maximum, decimal),
+                    _ => col_def.decimal(),
+                };
                 col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Float(num_attr) => {

--- a/src/postgres/probe.rs
+++ b/src/postgres/probe.rs
@@ -17,7 +17,7 @@ impl SchemaProbe for Postgres {
                 Condition::all()
                     .add(
                         Expr::expr(Self::get_current_schema())
-                            .equals(Schema::Tables, TablesFields::TableSchema),
+                            .equals((Schema::Tables, TablesFields::TableSchema)),
                     )
                     .add(Expr::col(TablesFields::TableType).eq("BASE TABLE")),
             )

--- a/src/postgres/query/constraints/mod.rs
+++ b/src/postgres/query/constraints/mod.rs
@@ -91,15 +91,15 @@ impl SchemaQueryBuilder {
                 Condition::all()
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::ConstraintName)
-                            .equals(Schema::CheckConstraints, Cf::ConstraintName),
+                            .equals((Schema::CheckConstraints, Cf::ConstraintName)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::ConstraintCatalog)
-                            .equals(Schema::CheckConstraints, Cf::ConstraintCatalog),
+                            .equals((Schema::CheckConstraints, Cf::ConstraintCatalog)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::ConstraintSchema)
-                            .equals(Schema::CheckConstraints, Cf::ConstraintSchema),
+                            .equals((Schema::CheckConstraints, Cf::ConstraintSchema)),
                     ),
             )
             .join(
@@ -108,27 +108,27 @@ impl SchemaQueryBuilder {
                 Condition::all()
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::ConstraintName)
-                            .equals(Schema::KeyColumnUsage, Kcuf::ConstraintName),
+                            .equals((Schema::KeyColumnUsage, Kcuf::ConstraintName)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::ConstraintCatalog)
-                            .equals(Schema::KeyColumnUsage, Kcuf::ConstraintCatalog),
+                            .equals((Schema::KeyColumnUsage, Kcuf::ConstraintCatalog)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::ConstraintSchema)
-                            .equals(Schema::KeyColumnUsage, Kcuf::ConstraintSchema),
+                            .equals((Schema::KeyColumnUsage, Kcuf::ConstraintSchema)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::TableCatalog)
-                            .equals(Schema::KeyColumnUsage, Kcuf::TableCatalog),
+                            .equals((Schema::KeyColumnUsage, Kcuf::TableCatalog)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::TableSchema)
-                            .equals(Schema::KeyColumnUsage, Kcuf::TableSchema),
+                            .equals((Schema::KeyColumnUsage, Kcuf::TableSchema)),
                     )
                     .add(
                         Expr::tbl(Schema::TableConstraints, Tcf::TableName)
-                            .equals(Schema::KeyColumnUsage, Kcuf::TableName),
+                            .equals((Schema::KeyColumnUsage, Kcuf::TableName)),
                     ),
             )
             .join_subquery(
@@ -151,12 +151,12 @@ impl SchemaQueryBuilder {
                     .left_join(
                         (Schema::Schema, Schema::ConstraintColumnUsage),
                         Expr::tbl(Schema::ReferentialConstraints, RefC::ConstraintName)
-                            .equals(Schema::ConstraintColumnUsage, Kcuf::ConstraintName),
+                            .equals((Schema::ConstraintColumnUsage, Kcuf::ConstraintName)),
                     )
                     .take(),
                 rcsq.clone(),
                 Expr::tbl(Schema::TableConstraints, Tcf::ConstraintName)
-                    .equals(rcsq.clone(), RefC::ConstraintName),
+                    .equals((rcsq.clone(), RefC::ConstraintName)),
             )
             .and_where(
                 Expr::col((Schema::TableConstraints, Tcf::TableSchema)).eq(schema.to_string()),

--- a/src/postgres/query/enumeration.rs
+++ b/src/postgres/query/enumeration.rs
@@ -36,7 +36,7 @@ impl SchemaQueryBuilder {
             .from(PgType::Table)
             .inner_join(
                 PgEnum::Table,
-                Expr::tbl(PgEnum::Table, PgEnum::EnumTypeId).equals(PgType::Table, PgType::Oid),
+                Expr::tbl(PgEnum::Table, PgEnum::EnumTypeId).equals((PgType::Table, PgType::Oid)),
             )
             .order_by((PgType::Table, PgType::TypeName), Order::Asc)
             .order_by((PgEnum::Table, PgEnum::EnumLabel), Order::Asc)

--- a/src/postgres/writer/column.rs
+++ b/src/postgres/writer/column.rs
@@ -54,9 +54,9 @@ impl ColumnInfo {
     pub fn write_col_type(&self) -> ColumnType {
         fn write_type(col_type: &Type) -> ColumnType {
             match col_type {
-                Type::SmallInt => ColumnType::SmallInteger(None),
-                Type::Integer => ColumnType::Integer(None),
-                Type::BigInt => ColumnType::BigInteger(None),
+                Type::SmallInt => ColumnType::SmallInteger,
+                Type::Integer => ColumnType::Integer,
+                Type::BigInt => ColumnType::BigInteger,
                 Type::Decimal(num_attr) | Type::Numeric(num_attr) => {
                     match (num_attr.precision, num_attr.scale) {
                         (None, None) => ColumnType::Decimal(None),
@@ -66,11 +66,11 @@ impl ColumnInfo {
                         ))),
                     }
                 }
-                Type::Real => ColumnType::Float(None),
-                Type::DoublePrecision => ColumnType::Double(None),
-                Type::SmallSerial => ColumnType::SmallInteger(None),
-                Type::Serial => ColumnType::Integer(None),
-                Type::BigSerial => ColumnType::BigInteger(None),
+                Type::Real => ColumnType::Float,
+                Type::DoublePrecision => ColumnType::Double,
+                Type::SmallSerial => ColumnType::SmallInteger,
+                Type::Serial => ColumnType::Integer,
+                Type::BigSerial => ColumnType::BigInteger,
                 Type::Money => ColumnType::Money(None),
                 Type::Varchar(string_attr) => {
                     ColumnType::String(string_attr.length.map(Into::into))
@@ -80,17 +80,11 @@ impl ColumnInfo {
                 Type::Bytea => ColumnType::Binary(BlobSize::Blob(None)),
                 // The SQL standard requires that writing just timestamp be equivalent to timestamp without time zone,
                 // and PostgreSQL honors that behavior. (https://www.postgresql.org/docs/current/datatype-datetime.html)
-                Type::Timestamp(time_attr) => {
-                    ColumnType::DateTime(time_attr.precision.map(Into::into))
-                }
-                Type::TimestampWithTimeZone(time_attr) => {
-                    ColumnType::TimestampWithTimeZone(time_attr.precision.map(Into::into))
-                }
+                Type::Timestamp(_) => ColumnType::DateTime,
+                Type::TimestampWithTimeZone(_) => ColumnType::TimestampWithTimeZone,
                 Type::Date => ColumnType::Date,
-                Type::Time(time_attr) => ColumnType::Time(time_attr.precision.map(Into::into)),
-                Type::TimeWithTimeZone(time_attr) => {
-                    ColumnType::Time(time_attr.precision.map(Into::into))
-                }
+                Type::Time(_) => ColumnType::Time,
+                Type::TimeWithTimeZone(_) => ColumnType::Time,
                 Type::Interval(interval_attr) => {
                     let field = match &interval_attr.field {
                         Some(field) => PgInterval::try_from(field).ok(),
@@ -146,9 +140,9 @@ impl ColumnInfo {
                         .collect();
                     ColumnType::Enum { name, variants }
                 }
-                Type::Array(array_def) => ColumnType::Array(SeaRc::new(Box::new(write_type(
+                Type::Array(array_def) => ColumnType::Array(SeaRc::new(write_type(
                     array_def.col_type.as_ref().expect("Array type not defined"),
-                )))),
+                ))),
             }
         }
         write_type(&self.col_type)

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -29,7 +29,7 @@ pub trait SchemaProbe {
                 Condition::all()
                     .add(
                         Expr::expr(Self::get_current_schema())
-                            .equals(Alias::new("columns"), Alias::new("table_schema")),
+                            .equals((Alias::new("columns"), Alias::new("table_schema"))),
                     )
                     .add(Expr::col(Alias::new("table_name")).eq(table.as_ref()))
                     .add(Expr::col(Alias::new("column_name")).eq(column.as_ref())),

--- a/tests/live/postgres/src/main.rs
+++ b/tests/live/postgres/src/main.rs
@@ -211,7 +211,7 @@ fn create_order_table() -> TableCreateStatement {
         )
         .col(
             ColumnDef::new(Alias::new("placed_at"))
-                .date_time_len(6)
+                .date_time()
                 .not_null(),
         )
         .primary_key(
@@ -333,9 +333,9 @@ fn create_collection_table() -> TableCreateStatement {
         )
         .col(
             ColumnDef::new(Alias::new("integers"))
-                .array(ColumnType::Integer(None))
+                .array(ColumnType::Integer)
                 .not_null(),
         )
-        .col(ColumnDef::new(Alias::new("integers_opt")).array(ColumnType::Integer(None)))
+        .col(ColumnDef::new(Alias::new("integers_opt")).array(ColumnType::Integer))
         .to_owned()
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-schema/issues/87

## Breaking Changes

- [x] Bump SeaQuery version to 0.28.x
- [x] Bump Minimum Supported Rust Version (MSRV) to 1.62
