### PR TITLE
Cleaning up dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,20 +34,20 @@ name = "sea_schema"
 path = "src/lib.rs"
 
 [dependencies]
-futures = { version = "0.3", optional = true }
-sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "0.28.0" }
-sea-query-binder = { version = "0.3", optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-sqlx = { version = "0.6", optional = true }
-log = { version = "0.4", optional = true }
+futures = { version = "0.3", default-features = false, optional = true, features = ["alloc"] }
+sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive", default-features = false }
+sea-query = { version = "0.28.0", default-features = false, features = ["derive"] }
+sea-query-binder = { version = "0.3", default-features = false, optional = true }
+serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
+sqlx = { version = "0.6", default-features = false, optional = true }
+log = { version = "0.4", default-features = false, optional = true }
 
 [features]
 default = ["mysql", "postgres", "sqlite", "discovery", "writer", "probe"]
 debug-print = ["log"]
-mysql = []
-postgres = []
-sqlite = []
+mysql = ["sea-query/backend-mysql"]
+postgres = ["sea-query/backend-postgres"]
+sqlite = ["sea-query/backend-sqlite"]
 def = []
 discovery = ["futures", "parser"]
 parser = ["query"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", optional = true }
 sea-schema-derive = { version = "0.1.0", path = "sea-schema-derive" }
-sea-query = { version = "^0.28.0" }
-sea-query-binder = { version = "^0.3", optional = true }
-serde = { version = "^1", features = ["derive"], optional = true }
-sqlx = { version = "^0.6", optional = true }
-log = { version = "^0.4", optional = true }
+sea-query = { version = "0.28.0" }
+sea-query-binder = { version = "0.3", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+sqlx = { version = "0.6", optional = true }
+log = { version = "0.4", optional = true }
 
 [features]
 default = ["mysql", "postgres", "sqlite", "discovery", "writer", "probe"]

--- a/sea-schema-derive/Cargo.toml
+++ b/sea-schema-derive/Cargo.toml
@@ -15,6 +15,6 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
-quote = "1"
-heck = "0.3"
-proc-macro2 = "1"
+quote = { version = "1", default-features = false }
+heck = { version = "0.3", default-features = false }
+proc-macro2 = { version = "1", default-features = false }

--- a/tests/discovery/mysql/Cargo.toml
+++ b/tests/discovery/mysql/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
-env_logger = { version = "^0" }
-log = { version = "^0" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/discovery/postgres/Cargo.toml
+++ b/tests/discovery/postgres/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
-env_logger = { version = "^0" }
-log = { version = "^0" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/discovery/sqlite/Cargo.toml
+++ b/tests/discovery/sqlite/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }

--- a/tests/live/mysql/Cargo.toml
+++ b/tests/live/mysql/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
-pretty_assertions = { version = "^0.7" }
-regex = { version = "^1" }
-env_logger = { version = "^0" }
-log = { version = "^0" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }
+pretty_assertions = { version = "0.7" }
+regex = { version = "1" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/live/postgres/Cargo.toml
+++ b/tests/live/postgres/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
-env_logger = { version = "^0" }
-log = { version = "^0" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/live/sqlite/Cargo.toml
+++ b/tests/live/sqlite/Cargo.toml
@@ -16,9 +16,9 @@ sea-schema = { path = "../../../", default-features = false, features = [
     "sqlx-sqlite",
     "sqlite",
 ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6", features = [
+serde_json = { version = "1" }
+sqlx = { version = "0.6", features = [
     "sqlite",
     "runtime-async-std-native-tls",
 ] }
-pretty_assertions = { version = "^0.7" }
+pretty_assertions = { version = "0.7" }

--- a/tests/migration/Cargo.toml
+++ b/tests/migration/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 sea-schema = { path = "../../", default-features = false, features = [ "migration" ] }
-sea-orm = { version = "^0.7.0", default-features = false, features = ["sqlx-all", "runtime-async-std-native-tls"] }
+sea-orm = { version = "0.7.0", default-features = false, features = ["sqlx-all", "runtime-async-std-native-tls"] }
 
 [dev-dependencies]
-env_logger = { version = "^0" }
-log = { version = "^0" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/writer/mysql/Cargo.toml
+++ b/tests/writer/mysql/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
-env_logger = { version = "^0" }
-log = { version = "^0" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/writer/postgres/Cargo.toml
+++ b/tests/writer/postgres/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-pretty_assertions = { version = "^0.7" }
+pretty_assertions = { version = "0.7" }
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
-env_logger = { version = "^0" }
-log = { version = "^0" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }
+env_logger = { version = "0" }
+log = { version = "0" }

--- a/tests/writer/sqlite/Cargo.toml
+++ b/tests/writer/sqlite/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
-serde_json = { version = "^1" }
-sqlx = { version = "^0.6" }
+serde_json = { version = "1" }
+sqlx = { version = "0.6" }


### PR DESCRIPTION
## PR Info

> Caret requirements are an alternative syntax for the default strategy, `^1.2.3` is exactly equivalent to `1.2.3`.
> 
> https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements

To make the dependency specification clear and concise, I'd like to define it all in the form of `x.y.z`.

## Changes

- [x] changed all `version = "^x.y.z"` into `version = "x.y.z"`
- [x] disable default features and enable only the needed ones
