### PR TITLE
Skip parsing empty Postgres check constraints

### DIFF
--- a/src/postgres/parser/table_constraints.rs
+++ b/src/postgres/parser/table_constraints.rs
@@ -31,12 +31,17 @@ impl Iterator for TableConstraintsQueryResultParser {
         let constraint_name = result.constraint_name;
         match result.constraint_type.as_str() {
             "CHECK" => {
-                Some(Constraint::Check(Check {
-                    name: constraint_name,
-                    expr: result.check_clause.unwrap(),
-                    // TODO: How to find?
-                    no_inherit: false,
-                }))
+                match result.check_clause {
+                    Some(check_clause) => {
+                        Some(Constraint::Check(Check {
+                            name: constraint_name,
+                            expr: check_clause,
+                            // TODO: How to find?
+                            no_inherit: false,
+                        }))
+                    }
+                    None => self.next(),
+                }
             }
 
             "FOREIGN KEY" => {


### PR DESCRIPTION
## PR Info

> okay now a new error: thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /Users/max/.cargo/registry/src/github.com-1ecc6299db9ec823/sea-schema-0.10.3/src/postgres/parser/table_constraints.rs:36:27

- Originated from https://discord.com/channels/873880840487206962/900758376164757555/1057084759223849050

## Bug Fixes

- [x] Skip parsing Postgres check constraints when check expression is empty
