### PR TITLE
Update heck dependecy

### DIFF
--- a/sea-schema-derive/Cargo.toml
+++ b/sea-schema-derive/Cargo.toml
@@ -16,5 +16,5 @@ proc-macro = true
 [dependencies]
 syn = { version = "1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
 quote = { version = "1", default-features = false }
-heck = { version = "0.3", default-features = false }
+heck = { version = "0.4", default-features = false }
 proc-macro2 = { version = "1", default-features = false }

--- a/sea-schema-derive/src/lib.rs
+++ b/sea-schema-derive/src/lib.rs
@@ -1,4 +1,4 @@
-use heck::SnakeCase;
+use heck::ToSnakeCase;
 use proc_macro::{self, TokenStream};
 use proc_macro2::Span;
 use quote::{quote, quote_spanned};


### PR DESCRIPTION
## New Features

- [ ] No

## Bug Fixes

- [ ] No

## Breaking Changes

- [ ] No

## Changes

- [ ] Update heck dependency to latest minor version to prevent including multiple versions in used `sea-orm` other crate dependent on `heck` latest version projects

Related with https://github.com/SeaQL/sea-orm/pull/1520 and https://github.com/SeaQL/strum/pull/1