### PR TITLE
fix: skip parsing partitioned Postgres tables

### DIFF
--- a/src/postgres/query/constraints/mod.rs
+++ b/src/postgres/query/constraints/mod.rs
@@ -9,7 +9,7 @@ pub use referential_constraints::*;
 pub use table_constraints::*;
 
 use super::{InformationSchema, SchemaQueryBuilder};
-use crate::sqlx_types::postgres::PgRow;
+use crate::{postgres::query::select_table_and_view, sqlx_types::postgres::PgRow};
 use sea_query::{Alias, Condition, Expr, Iden, JoinType, Order, Query, SeaRc, SelectStatement};
 
 #[derive(Debug, Default)]
@@ -162,6 +162,9 @@ impl SchemaQueryBuilder {
                 Expr::col((Schema::TableConstraints, Tcf::TableSchema)).eq(schema.to_string()),
             )
             .and_where(Expr::col((Schema::TableConstraints, Tcf::TableName)).eq(table.to_string()))
+            .and_where(
+                Expr::col((rcsq.clone(), Kcuf::TableName)).not_in_subquery(select_table_and_view()),
+            )
             .order_by((Schema::TableConstraints, Tcf::ConstraintName), Order::Asc)
             .order_by((Schema::KeyColumnUsage, Kcuf::OrdinalPosition), Order::Asc)
             .order_by((rcsq.clone(), RefC::UniqueConstraintName), Order::Asc)

--- a/src/postgres/query/constraints/mod.rs
+++ b/src/postgres/query/constraints/mod.rs
@@ -9,7 +9,7 @@ pub use referential_constraints::*;
 pub use table_constraints::*;
 
 use super::{InformationSchema, SchemaQueryBuilder};
-use crate::{postgres::query::select_table_and_view, sqlx_types::postgres::PgRow};
+use crate::{postgres::query::select_base_table_and_view, sqlx_types::postgres::PgRow};
 use sea_query::{Alias, Condition, Expr, Iden, JoinType, Order, Query, SeaRc, SelectStatement};
 
 #[derive(Debug, Default)]
@@ -163,7 +163,8 @@ impl SchemaQueryBuilder {
             )
             .and_where(Expr::col((Schema::TableConstraints, Tcf::TableName)).eq(table.to_string()))
             .and_where(
-                Expr::col((rcsq.clone(), Kcuf::TableName)).not_in_subquery(select_table_and_view()),
+                Expr::col((rcsq.clone(), Kcuf::TableName))
+                    .not_in_subquery(select_base_table_and_view()),
             )
             .order_by((Schema::TableConstraints, Tcf::ConstraintName), Order::Asc)
             .order_by((Schema::KeyColumnUsage, Kcuf::OrdinalPosition), Order::Asc)

--- a/src/postgres/query/schema.rs
+++ b/src/postgres/query/schema.rs
@@ -17,7 +17,7 @@ pub enum InformationSchema {
     ConstraintColumnUsage,
 }
 
-pub(crate) fn select_table_and_view() -> SelectStatement {
+pub(crate) fn select_base_table_and_view() -> SelectStatement {
     #[derive(Debug, Iden)]
     enum PgClass {
         Table,

--- a/src/postgres/query/schema.rs
+++ b/src/postgres/query/schema.rs
@@ -19,7 +19,7 @@ pub enum InformationSchema {
 
 pub(crate) fn select_table_and_view() -> SelectStatement {
     #[derive(Debug, Iden)]
-    pub enum PgClass {
+    enum PgClass {
         Table,
         Relname,
         Relkind,
@@ -27,7 +27,7 @@ pub(crate) fn select_table_and_view() -> SelectStatement {
     }
 
     #[derive(Debug, Iden)]
-    pub enum PgInherits {
+    enum PgInherits {
         Table,
         Inhrelid,
     }

--- a/src/postgres/query/schema.rs
+++ b/src/postgres/query/schema.rs
@@ -44,6 +44,21 @@ pub(crate) fn select_table_and_view() -> SelectStatement {
                         .equals((PgClass::Table, PgClass::Oid)),
                 )
                 .add(
+                    // List of possible value of the `relkind` column.
+                    // ========
+                    // r = ordinary table
+                    // i = index
+                    // S = sequence
+                    // t = TOAST table
+                    // v = view
+                    // m = materialized view
+                    // c = composite type
+                    // f = foreign table
+                    // p = partitioned table
+                    // I = partitioned index
+                    // Extracted from https://www.postgresql.org/docs/current/catalog-pg-class.html
+                    //
+                    // We want to select tables and views only.
                     Expr::col((PgClass::Table, PgClass::Relkind))
                         .is_in(["r", "t", "v", "m", "f", "p"]),
                 ),

--- a/src/postgres/query/table.rs
+++ b/src/postgres/query/table.rs
@@ -1,4 +1,4 @@
-use super::{InformationSchema, SchemaQueryBuilder};
+use super::{select_table_and_view, InformationSchema, SchemaQueryBuilder};
 use crate::sqlx_types::postgres::PgRow;
 use sea_query::{Expr, Iden, Query, SeaRc, SelectStatement};
 
@@ -46,6 +46,7 @@ impl SchemaQueryBuilder {
             .from((InformationSchema::Schema, InformationSchema::Tables))
             .and_where(Expr::col(TablesFields::TableSchema).eq(schema.to_string()))
             .and_where(Expr::col(TablesFields::TableType).eq(TableType::BaseTable.to_string()))
+            .and_where(Expr::col(TablesFields::TableName).not_in_subquery(select_table_and_view()))
             .take()
     }
 }

--- a/src/postgres/query/table.rs
+++ b/src/postgres/query/table.rs
@@ -1,4 +1,4 @@
-use super::{select_table_and_view, InformationSchema, SchemaQueryBuilder};
+use super::{select_base_table_and_view, InformationSchema, SchemaQueryBuilder};
 use crate::sqlx_types::postgres::PgRow;
 use sea_query::{Expr, Iden, Query, SeaRc, SelectStatement};
 
@@ -46,7 +46,9 @@ impl SchemaQueryBuilder {
             .from((InformationSchema::Schema, InformationSchema::Tables))
             .and_where(Expr::col(TablesFields::TableSchema).eq(schema.to_string()))
             .and_where(Expr::col(TablesFields::TableType).eq(TableType::BaseTable.to_string()))
-            .and_where(Expr::col(TablesFields::TableName).not_in_subquery(select_table_and_view()))
+            .and_where(
+                Expr::col(TablesFields::TableName).not_in_subquery(select_base_table_and_view()),
+            )
             .take()
     }
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1582

## Bug Fixes

- [x] skip parsing partitioned Postgres tables
