### PR TITLE
Upgrade to SeaQuery 0.29.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ path = "src/lib.rs"
 [dependencies]
 futures = { version = "0.3", default-features = false, optional = true, features = ["alloc"] }
 sea-schema-derive = { version = "0.2.0", path = "sea-schema-derive", default-features = false }
-sea-query = { version = "0.29.0-rc.1", default-features = false, features = ["derive"] }
-sea-query-binder = { version = "0.4.0-rc.1", default-features = false, optional = true }
+sea-query = { version = "0.29.0-rc.2", default-features = false, features = ["derive"] }
+sea-query-binder = { version = "0.4.0-rc.2", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 sqlx = { version = "0.6", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }

--- a/src/postgres/def/types.rs
+++ b/src/postgres/def/types.rs
@@ -1,4 +1,4 @@
-use sea_query::SeaRc;
+use sea_query::RcOrArc;
 #[cfg(feature = "with-serde")]
 use serde::{Deserialize, Serialize};
 
@@ -261,7 +261,7 @@ pub struct EnumDef {
 #[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub struct ArrayDef {
     /// Array type
-    pub col_type: Option<SeaRc<Type>>,
+    pub col_type: Option<RcOrArc<Type>>,
 }
 
 impl Type {

--- a/src/postgres/parser/column.rs
+++ b/src/postgres/parser/column.rs
@@ -1,7 +1,7 @@
 use crate::postgres::{
     def::*, discovery::EnumVariantMap, parser::yes_or_no_to_bool, query::ColumnQueryResult,
 };
-use sea_query::SeaRc;
+use sea_query::RcOrArc;
 
 impl ColumnQueryResult {
     pub fn parse(self, enums: &EnumVariantMap) -> ColumnInfo {
@@ -215,7 +215,7 @@ pub fn parse_array_attributes(
                 Some(typename) => {
                     let typename = typename.replacen("[]", "", 1);
                     let is_enum = enums.contains_key(&typename);
-                    Some(SeaRc::new(Type::from_str(
+                    Some(RcOrArc::new(Type::from_str(
                         &typename,
                         Some(&typename),
                         is_enum,

--- a/src/postgres/writer/column.rs
+++ b/src/postgres/writer/column.rs
@@ -1,5 +1,5 @@
 use crate::postgres::def::{ColumnInfo, Type};
-use sea_query::{Alias, BlobSize, ColumnDef, ColumnType, DynIden, IntoIden, PgInterval, SeaRc};
+use sea_query::{Alias, BlobSize, ColumnDef, ColumnType, DynIden, IntoIden, PgInterval, RcOrArc};
 use std::{convert::TryFrom, fmt::Write};
 
 impl ColumnInfo {
@@ -140,7 +140,7 @@ impl ColumnInfo {
                         .collect();
                     ColumnType::Enum { name, variants }
                 }
-                Type::Array(array_def) => ColumnType::Array(SeaRc::new(write_type(
+                Type::Array(array_def) => ColumnType::Array(RcOrArc::new(write_type(
                     array_def.col_type.as_ref().expect("Array type not defined"),
                 ))),
             }


### PR DESCRIPTION
## PR Info

## Breaking Changes

- [x] Replace the use of `SeaRc<T>` where `T` isn't `dyn Iden` to `RcOrArc<T>`

