### PR TITLE
Return `Result`s from DB executor functions

### DIFF
--- a/src/mysql/discovery/executor/mock.rs
+++ b/src/mysql/discovery/executor/mock.rs
@@ -19,7 +19,7 @@ impl IntoExecutor for MySqlPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Vec<MySqlRow> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<MySqlRow>, sqlx::Error> {
         let (_sql, _values) = select.build(MysqlQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 

--- a/src/mysql/discovery/executor/mock.rs
+++ b/src/mysql/discovery/executor/mock.rs
@@ -1,7 +1,7 @@
 use crate::sqlx_types::{mysql::MySqlRow, MySqlPool};
 use sea_query::{MysqlQueryBuilder, SelectStatement};
 
-use crate::debug_print;
+use crate::{debug_print, sqlx_types::SqlxError};
 
 #[allow(dead_code)]
 pub struct Executor {
@@ -19,7 +19,7 @@ impl IntoExecutor for MySqlPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<MySqlRow>, sqlx::Error> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<MySqlRow>, SqlxError> {
         let (_sql, _values) = select.build(MysqlQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 

--- a/src/mysql/discovery/executor/real.rs
+++ b/src/mysql/discovery/executor/real.rs
@@ -19,13 +19,12 @@ impl IntoExecutor for MySqlPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Vec<MySqlRow> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<MySqlRow>, sqlx::Error> {
         let (sql, values) = select.build_sqlx(MysqlQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
             .fetch_all(&mut self.pool.acquire().await.unwrap())
             .await
-            .unwrap()
     }
 }

--- a/src/mysql/discovery/executor/real.rs
+++ b/src/mysql/discovery/executor/real.rs
@@ -24,7 +24,7 @@ impl Executor {
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
-            .fetch_all(&mut self.pool.acquire().await.unwrap())
+            .fetch_all(&mut self.pool.acquire().await?)
             .await
     }
 }

--- a/src/mysql/discovery/executor/real.rs
+++ b/src/mysql/discovery/executor/real.rs
@@ -2,7 +2,7 @@ use sea_query::{MysqlQueryBuilder, SelectStatement};
 use sea_query_binder::SqlxBinder;
 use sqlx::{mysql::MySqlRow, MySqlPool};
 
-use crate::debug_print;
+use crate::{debug_print, sqlx_types::SqlxError};
 
 pub struct Executor {
     pool: MySqlPool,
@@ -19,7 +19,7 @@ impl IntoExecutor for MySqlPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<MySqlRow>, sqlx::Error> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<MySqlRow>, SqlxError> {
         let (sql, values) = select.build_sqlx(MysqlQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 

--- a/src/mysql/discovery/mod.rs
+++ b/src/mysql/discovery/mod.rs
@@ -33,12 +33,11 @@ impl SchemaDiscovery {
     }
 
     pub async fn discover(mut self) -> Result<Schema, SqlxError> {
-        let system_opt = self.discover_system().await?;
-        let system = match system_opt {
-            Some(system) => system,
-            None => return Err(SqlxError::RowNotFound),
-        };
-        self.query = SchemaQueryBuilder::new(system);
+        let system_info = self
+            .discover_system()
+            .await
+            .and_then(|system_info_opt| system_info_opt.ok_or(SqlxError::RowNotFound))?;
+        self.query = SchemaQueryBuilder::new(system_info);
         let tables = self.discover_tables().await?;
         let tables = future::try_join_all(
             tables

--- a/src/postgres/discovery/executor/mock.rs
+++ b/src/postgres/discovery/executor/mock.rs
@@ -1,7 +1,7 @@
 use crate::sqlx_types::{postgres::PgRow, PgPool};
 use sea_query::{PostgresQueryBuilder, SelectStatement};
 
-use crate::debug_print;
+use crate::{debug_print, sqlx_types::SqlxError};
 
 #[allow(dead_code)]
 pub struct Executor {
@@ -19,7 +19,7 @@ impl IntoExecutor for PgPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<PgRow>, sqlx::Error> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<PgRow>, SqlxError> {
         let (_sql, _values) = select.build(PostgresQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 

--- a/src/postgres/discovery/executor/mock.rs
+++ b/src/postgres/discovery/executor/mock.rs
@@ -19,7 +19,7 @@ impl IntoExecutor for PgPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Vec<PgRow> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<PgRow>, sqlx::Error> {
         let (_sql, _values) = select.build(PostgresQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 

--- a/src/postgres/discovery/executor/real.rs
+++ b/src/postgres/discovery/executor/real.rs
@@ -2,7 +2,7 @@ use sea_query::{PostgresQueryBuilder, SelectStatement};
 use sea_query_binder::SqlxBinder;
 use sqlx::{postgres::PgRow, PgPool};
 
-use crate::debug_print;
+use crate::{debug_print, sqlx_types::SqlxError};
 
 pub struct Executor {
     pool: PgPool,
@@ -19,7 +19,7 @@ impl IntoExecutor for PgPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<PgRow>, sqlx::Error> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<PgRow>, SqlxError> {
         let (sql, values) = select.build_sqlx(PostgresQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 

--- a/src/postgres/discovery/executor/real.rs
+++ b/src/postgres/discovery/executor/real.rs
@@ -24,7 +24,7 @@ impl Executor {
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
-            .fetch_all(&mut self.pool.acquire().await.unwrap())
+            .fetch_all(&mut self.pool.acquire().await?)
             .await
     }
 }

--- a/src/postgres/discovery/executor/real.rs
+++ b/src/postgres/discovery/executor/real.rs
@@ -19,13 +19,12 @@ impl IntoExecutor for PgPool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Vec<PgRow> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<PgRow>, sqlx::Error> {
         let (sql, values) = select.build_sqlx(PostgresQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
             .fetch_all(&mut self.pool.acquire().await.unwrap())
             .await
-            .unwrap()
     }
 }

--- a/src/sqlite/def/table.rs
+++ b/src/sqlite/def/table.rs
@@ -57,7 +57,7 @@ impl TableDef {
             .and_where(Expr::col(Alias::new("sql")).like("%AUTOINCREMENT%"))
             .to_owned();
 
-        if !executor.fetch_all(check_autoincrement).await.is_empty() {
+        if !executor.fetch_all(check_autoincrement).await?.is_empty() {
             self.auto_increment = true;
         }
 
@@ -77,7 +77,7 @@ impl TableDef {
         index_query.push_str(&self.name);
         index_query.push_str("')");
 
-        let partial_index_info_rows = executor.fetch_all_raw(index_query).await;
+        let partial_index_info_rows = executor.fetch_all_raw(index_query).await?;
         let mut partial_indexes: Vec<PartialIndexInfo> = Vec::default();
 
         partial_index_info_rows.iter().for_each(|info| {
@@ -114,7 +114,7 @@ impl TableDef {
         index_query.push_str(&self.name);
         index_query.push_str("')");
 
-        let index_info_rows = executor.fetch_all_raw(index_query).await;
+        let index_info_rows = executor.fetch_all_raw(index_query).await?;
 
         index_info_rows.iter().for_each(|info| {
             let index_info: ForeignKeysInfo = info.into();
@@ -132,7 +132,7 @@ impl TableDef {
         index_query.push_str(&self.name);
         index_query.push_str("')");
 
-        let index_info_rows = executor.fetch_all_raw(index_query).await;
+        let index_info_rows = executor.fetch_all_raw(index_query).await?;
 
         for info in index_info_rows {
             let column = ColumnInfo::to_column_def(&info)?;
@@ -154,7 +154,7 @@ impl TableDef {
             .and_where(Expr::col(Alias::new("name")).eq(index_name))
             .to_owned();
 
-        let index_info = executor.fetch_one(index_query).await;
+        let index_info = executor.fetch_one(index_query).await?;
 
         Ok((&index_info).into())
     }

--- a/src/sqlite/discovery.rs
+++ b/src/sqlite/discovery.rs
@@ -28,7 +28,7 @@ impl SchemaDiscovery {
             .to_owned();
 
         let mut tables = Vec::new();
-        for row in self.executor.fetch_all(get_tables).await {
+        for row in self.executor.fetch_all(get_tables).await? {
             let mut table: TableDef = (&row).into();
             table.pk_is_autoincrement(&self.executor).await?;
             table.get_foreign_keys(&self.executor).await?;
@@ -49,7 +49,7 @@ impl SchemaDiscovery {
             .to_owned();
 
         let mut tables = Vec::new();
-        let rows = self.executor.fetch_all(get_tables).await;
+        let rows = self.executor.fetch_all(get_tables).await?;
         for row in rows {
             let table: TableDef = (&row).into();
             tables.push(table);

--- a/src/sqlite/error.rs
+++ b/src/sqlite/error.rs
@@ -1,6 +1,6 @@
 use std::num::{ParseFloatError, ParseIntError};
 
-use crate::sqlx_types::Error as SqlxError;
+use crate::sqlx_types::SqlxError;
 
 /// This type simplifies error handling
 pub type DiscoveryResult<T> = Result<T, SqliteDiscoveryError>;
@@ -12,7 +12,7 @@ pub enum SqliteDiscoveryError {
     ParseIntError,
     /// An error parsing a string from the result of an SQLite query into an rust-language float
     ParseFloatError,
-    /// The error as defined in [sqlx::Error]
+    /// The error as defined in [SqlxError]
     SqlxError(SqlxError),
     /// An operation to discover the indexes in a table was invoked
     /// but the target table contains no indexes

--- a/src/sqlite/executor/mock.rs
+++ b/src/sqlite/executor/mock.rs
@@ -1,7 +1,7 @@
 use crate::sqlx_types::{sqlite::SqliteRow, SqlitePool};
 use sea_query::{SelectStatement, SqliteQueryBuilder};
 
-use crate::debug_print;
+use crate::{debug_print, sqlx_types::SqlxError};
 
 #[allow(dead_code)]
 pub struct Executor {
@@ -19,21 +19,21 @@ impl IntoExecutor for SqlitePool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<SqliteRow>, sqlx::Error> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<SqliteRow>, SqlxError> {
         let (_sql, _values) = select.build(SqliteQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 
         panic!("This is a mock Executor");
     }
 
-    pub async fn fetch_one(&self, select: SelectStatement) -> Result<SqliteRow, sqlx::Error> {
+    pub async fn fetch_one(&self, select: SelectStatement) -> Result<SqliteRow, SqlxError> {
         let (_sql, _values) = select.build(SqliteQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 
         panic!("This is a mock Executor");
     }
 
-    pub async fn fetch_all_raw(&self, _sql: String) -> Result<Vec<SqliteRow>, sqlx::Error> {
+    pub async fn fetch_all_raw(&self, _sql: String) -> Result<Vec<SqliteRow>, SqlxError> {
         debug_print!("{}", _sql);
 
         panic!("This is a mock Executor");

--- a/src/sqlite/executor/mock.rs
+++ b/src/sqlite/executor/mock.rs
@@ -19,21 +19,21 @@ impl IntoExecutor for SqlitePool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Vec<SqliteRow> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<SqliteRow>, sqlx::Error> {
         let (_sql, _values) = select.build(SqliteQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 
         panic!("This is a mock Executor");
     }
 
-    pub async fn fetch_one(&self, select: SelectStatement) -> SqliteRow {
+    pub async fn fetch_one(&self, select: SelectStatement) -> Result<SqliteRow, sqlx::Error> {
         let (_sql, _values) = select.build(SqliteQueryBuilder);
         debug_print!("{}, {:?}", _sql, _values);
 
         panic!("This is a mock Executor");
     }
 
-    pub async fn fetch_all_raw(&self, _sql: String) -> Vec<SqliteRow> {
+    pub async fn fetch_all_raw(&self, _sql: String) -> Result<Vec<SqliteRow>, sqlx::Error> {
         debug_print!("{}", _sql);
 
         panic!("This is a mock Executor");

--- a/src/sqlite/executor/real.rs
+++ b/src/sqlite/executor/real.rs
@@ -19,32 +19,29 @@ impl IntoExecutor for SqlitePool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Vec<SqliteRow> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<SqliteRow>, sqlx::Error> {
         let (sql, values) = select.build_sqlx(SqliteQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
             .fetch_all(&mut self.pool.acquire().await.unwrap())
             .await
-            .unwrap()
     }
 
-    pub async fn fetch_one(&self, select: SelectStatement) -> SqliteRow {
+    pub async fn fetch_one(&self, select: SelectStatement) -> Result<SqliteRow, sqlx::Error> {
         let (sql, values) = select.build_sqlx(SqliteQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
             .fetch_one(&mut self.pool.acquire().await.unwrap())
             .await
-            .unwrap()
     }
 
-    pub async fn fetch_all_raw(&self, sql: String) -> Vec<SqliteRow> {
+    pub async fn fetch_all_raw(&self, sql: String) -> Result<Vec<SqliteRow>, sqlx::Error> {
         debug_print!("{}", sql);
 
         sqlx::query(&sql)
             .fetch_all(&mut self.pool.acquire().await.unwrap())
             .await
-            .unwrap()
     }
 }

--- a/src/sqlite/executor/real.rs
+++ b/src/sqlite/executor/real.rs
@@ -24,7 +24,7 @@ impl Executor {
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
-            .fetch_all(&mut self.pool.acquire().await.unwrap())
+            .fetch_all(&mut self.pool.acquire().await?)
             .await
     }
 
@@ -33,7 +33,7 @@ impl Executor {
         debug_print!("{}, {:?}", sql, values);
 
         sqlx::query_with(&sql, values)
-            .fetch_one(&mut self.pool.acquire().await.unwrap())
+            .fetch_one(&mut self.pool.acquire().await?)
             .await
     }
 
@@ -41,7 +41,7 @@ impl Executor {
         debug_print!("{}", sql);
 
         sqlx::query(&sql)
-            .fetch_all(&mut self.pool.acquire().await.unwrap())
+            .fetch_all(&mut self.pool.acquire().await?)
             .await
     }
 }

--- a/src/sqlite/executor/real.rs
+++ b/src/sqlite/executor/real.rs
@@ -2,7 +2,7 @@ use sea_query::{SelectStatement, SqliteQueryBuilder};
 use sea_query_binder::SqlxBinder;
 use sqlx::{sqlite::SqliteRow, SqlitePool};
 
-use crate::debug_print;
+use crate::{debug_print, sqlx_types::SqlxError};
 
 pub struct Executor {
     pool: SqlitePool,
@@ -19,7 +19,7 @@ impl IntoExecutor for SqlitePool {
 }
 
 impl Executor {
-    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<SqliteRow>, sqlx::Error> {
+    pub async fn fetch_all(&self, select: SelectStatement) -> Result<Vec<SqliteRow>, SqlxError> {
         let (sql, values) = select.build_sqlx(SqliteQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
@@ -28,7 +28,7 @@ impl Executor {
             .await
     }
 
-    pub async fn fetch_one(&self, select: SelectStatement) -> Result<SqliteRow, sqlx::Error> {
+    pub async fn fetch_one(&self, select: SelectStatement) -> Result<SqliteRow, SqlxError> {
         let (sql, values) = select.build_sqlx(SqliteQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
@@ -37,7 +37,7 @@ impl Executor {
             .await
     }
 
-    pub async fn fetch_all_raw(&self, sql: String) -> Result<Vec<SqliteRow>, sqlx::Error> {
+    pub async fn fetch_all_raw(&self, sql: String) -> Result<Vec<SqliteRow>, SqlxError> {
         debug_print!("{}", sql);
 
         sqlx::query(&sql)

--- a/src/sqlx_types/mock.rs
+++ b/src/sqlx_types/mock.rs
@@ -22,3 +22,8 @@ pub trait Row {}
 
 #[derive(Debug)]
 pub struct Error;
+
+#[derive(Debug)]
+pub enum SqlxError {
+    RowNotFound,
+}

--- a/src/sqlx_types/real.rs
+++ b/src/sqlx_types/real.rs
@@ -1,1 +1,3 @@
 pub use sqlx::*;
+
+pub type SqlxError = sqlx::Error;

--- a/tests/live/mysql/src/main.rs
+++ b/tests/live/mysql/src/main.rs
@@ -41,7 +41,10 @@ async fn main() {
 
     let schema_discovery = SchemaDiscovery::new(connection, "sea-schema");
 
-    let schema = schema_discovery.discover().await;
+    let schema = schema_discovery
+        .discover()
+        .await
+        .expect("Error discovering schema");
 
     println!("{:#?}", schema);
 

--- a/tests/live/postgres/src/main.rs
+++ b/tests/live/postgres/src/main.rs
@@ -63,7 +63,10 @@ async fn main() {
 
     let schema_discovery = SchemaDiscovery::new(connection, "public");
 
-    let schema = schema_discovery.discover().await;
+    let schema = schema_discovery
+        .discover()
+        .await
+        .expect("Error discovering schema");
 
     println!("{:#?}", schema);
 
@@ -89,7 +92,10 @@ async fn main() {
         assert_eq!(expected_sql, sql);
     }
 
-    let enum_defs = schema_discovery.discover_enums().await;
+    let enum_defs = schema_discovery
+        .discover_enums()
+        .await
+        .expect("Error discovering enums");
 
     dbg!(&enum_defs);
 

--- a/tests/writer/mysql/src/main.rs
+++ b/tests/writer/mysql/src/main.rs
@@ -16,7 +16,10 @@ async fn main() {
 
     let schema_discovery = SchemaDiscovery::new(connection, "sakila");
 
-    let schema = schema_discovery.discover().await;
+    let schema = schema_discovery
+        .discover()
+        .await
+        .expect("Error discovering schema");
 
     for table in schema.tables.iter() {
         println!("{};", table.write().to_string(MysqlQueryBuilder));

--- a/tests/writer/postgres/src/main.rs
+++ b/tests/writer/postgres/src/main.rs
@@ -16,7 +16,10 @@ async fn main() {
 
     let schema_discovery = SchemaDiscovery::new(connection, "public");
 
-    let schema = schema_discovery.discover().await;
+    let schema = schema_discovery
+        .discover()
+        .await
+        .expect("Error discovering schema");
 
     for table in schema.tables.iter() {
         println!("{};", table.write().to_string(PostgresQueryBuilder));


### PR DESCRIPTION
Previously, the code for `Executor::fetch_all` and similar functions used `.unwrap()` internally and panicked if any error happened during the call.  This could result in schema detection causing panics in cases of things like spurious network issues, connection pool exhaustion, and other transitory issues with the DB.

## PR Info

Fixes #106

## Breaking Changes

This introduces a breaking change to the crate's public API surface.  Callers will need to be updated to handle the fact that schema detection returns `Result`s now.

This is definitely unavoidable, but updating shouldn't be too difficult.  Callers can just `.unwrap()` to retain the existing behavior of panicking in the case of any DB or connection error.

## Changes

 * Migrate all of the executor functions to return `Result<T, sqlx::Error>` to bubble up errors
 * Update all schema detection functions to bubble up errors as well and migrate code to handle addition of `Result` return types

