### PR TITLE
Upgrade `syn` to `2`

### DIFF
--- a/sea-schema-derive/Cargo.toml
+++ b/sea-schema-derive/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [ "database", "sql", "mysql", "postgres", "sqlite" ]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
+syn = { version = "2", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
 quote = { version = "1", default-features = false }
 heck = { version = "0.4", default-features = false }
 proc-macro2 = { version = "1", default-features = false }


### PR DESCRIPTION
## PR Info

- Closes #128

## New Features

- Upgrades Syn from v1 to v2; No change in outputs should be present, though existing tests were somewhat sparse.

## Changes

- Utilizes direct emplacement of expressions instead of collapsing into literals where applicable, as `syn` v2 no longer surfaces literals directly for attributes.