### PR TITLE
Fix enum values ordering

### DIFF
--- a/src/postgres/query/enumeration.rs
+++ b/src/postgres/query/enumeration.rs
@@ -20,6 +20,8 @@ pub enum PgEnum {
     EnumLabel,
     #[iden = "enumtypid"]
     EnumTypeId,
+    #[iden = "enumsortorder"]
+    EnumSortOrder,
 }
 
 #[derive(Debug, Default)]
@@ -39,6 +41,7 @@ impl SchemaQueryBuilder {
                 Expr::col((PgEnum::Table, PgEnum::EnumTypeId)).equals((PgType::Table, PgType::Oid)),
             )
             .order_by((PgType::Table, PgType::TypeName), Order::Asc)
+            .order_by((PgEnum::Table, PgEnum::EnumSortOrder), Order::Asc)
             .order_by((PgEnum::Table, PgEnum::EnumLabel), Order::Asc)
             .take()
     }


### PR DESCRIPTION
## PR Info

- Closes [#2285](https://github.com/SeaQL/sea-orm/issues/2285)

## Bug Fixes

- [#2285 Generated Rust enum ordering does not match underlying database enum ordering]
