### PR TITLE
chore(mysql): map medium int to int, tinytext to varchar(255)

### DIFF
--- a/src/mysql/writer/column.rs
+++ b/src/mysql/writer/column.rs
@@ -75,9 +75,12 @@ impl ColumnInfo {
                 };
                 col_def = self.write_num_attr(col_def, num_attr);
             }
-            Type::MediumInt(_) => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+            Type::MediumInt(num_attr) => {
+                match num_attr.unsigned {
+                    Some(_) => col_def.unsigned(),
+                    None => col_def.integer(),
+                };
+                col_def = self.write_num_attr(col_def, num_attr);
             }
             Type::Int(num_attr) => {
                 match num_attr.unsigned {
@@ -169,8 +172,9 @@ impl ColumnInfo {
                 col_def = self.write_str_attr(col_def, str_attr);
             }
             Type::TinyText(_) => {
-                // FIXME: Unresolved type mapping
-                col_def.custom(self.col_type.clone());
+                // map to varchar(255)
+                col_def.string_len(255);
+                col_def.extra(format!("CHARACTER SET {}", CharSet::Utf8.to_string()));
             }
             Type::MediumText(_) => {
                 // FIXME: Unresolved type mapping


### PR DESCRIPTION
for most usage case, `medium int` and `tinytext` in schema is due to history reason, I mean, for legacy projects.

generate `custom(xxx)` type code is not very helpful in real life.


## PR Info

## Breaking Changes

mysql: map `medium int` to `int`
mysql: map `tinytext` to `varchar(255)`


