### PR TITLE
Fix sqlite primary key not null

### DIFF
--- a/src/sqlite/def/column.rs
+++ b/src/sqlite/def/column.rs
@@ -30,7 +30,7 @@ impl ColumnInfo {
             cid: row.get(0),
             name: row.get(1),
             r#type: super::parse_type(row.get(2))?,
-            not_null: col_not_null != 0,
+            not_null: col_not_null = 1 || is_pk = 1,
             default_value: if default_value == "NULL" {
                 DefaultType::Null
             } else if default_value.is_empty() {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

In SQLite, the not_null value for a primary key can be 0, even though it cannot actually be NULL.
```
sqlite> create table foo (id INTEGER PRIMARY KEY AUTOINCREMENT);
sqlite> PRAGMA table_info(foo);
0|id|INTEGER|0||1
sqlite> create table bar (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL);
sqlite> PRAGMA table_info(bar);
0|id|INTEGER|1||1
```

<!-- mention the related issue -->
- Closes SeaQL/sea-orm#2051 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] not_null of sqlite primary key will always be true
