### PR TITLE
Make sqlite ForeignKeysInfo fields accessible

### DIFF
--- a/src/sqlite/def/column.rs
+++ b/src/sqlite/def/column.rs
@@ -185,17 +185,17 @@ impl From<&SqliteRow> for PrimaryKeyAutoincrement {
 }
 
 /// Indexes the foreign keys
-#[allow(dead_code)]
 #[derive(Debug, Default, Clone)]
+#[non_exhaustive]
 pub struct ForeignKeysInfo {
-    pub(crate) id: i32,
-    pub(crate) seq: i32,
-    pub(crate) table: String,
-    pub(crate) from: Vec<String>,
-    pub(crate) to: Vec<String>,
-    pub(crate) on_update: ForeignKeyAction,
-    pub(crate) on_delete: ForeignKeyAction,
-    pub(crate) r#match: MatchAction,
+    pub id: i32,
+    pub seq: i32,
+    pub table: String,
+    pub from: Vec<String>,
+    pub to: Vec<String>,
+    pub on_update: ForeignKeyAction,
+    pub on_delete: ForeignKeyAction,
+    pub r#match: MatchAction,
 }
 
 #[cfg(feature = "sqlx-sqlite")]


### PR DESCRIPTION
We are writing migration tests, and using this library to assert the schema before and after migrations, for that we want to access as much information as possible about the general schema of the database.

- Closes  https://github.com/SeaQL/sea-schema/issues/62


## New Features

- [ ] Making all the fields public but marking the struct as `#[non_exhaustive]` for forwards compatibility
- ~[ ] Expose public fields on `ForeignKeysInfo` as close as possible to the postgres: https://docs.rs/sea-schema/latest/sea_schema/postgres/def/struct.References.html~


## Alternatives
- Expose public fields on `ForeignKeysInfo` as close as possible to the postgres: https://docs.rs/sea-schema/latest/sea_schema/postgres/def/struct.References.html
- Replacing the public fields with getters.
- ~Making all the fields public but marking the struct as `#[non_exhaustive]` for forwards compatibility~

I chose the lowest common ground I could think but I'm more than willing to modify this PR to be any of the alternatives.

Thank you!
