### PR TITLE
Implement PartialEq for Sqlite schemas.

### DIFF
--- a/src/sqlite/def/column.rs
+++ b/src/sqlite/def/column.rs
@@ -63,7 +63,7 @@ impl ColumnInfo {
 /// Maps the index and all columns in the index which is the result of queries
 /// `PRAGMA index_list(table_name)` and
 /// `SELECT * FROM sqlite_master where name = 'index_name'`
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct IndexInfo {
     /// Is it a SQLindex
     pub r#type: String,
@@ -185,7 +185,7 @@ impl From<&SqliteRow> for PrimaryKeyAutoincrement {
 }
 
 /// Indexes the foreign keys
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct ForeignKeysInfo {
     pub id: i32,

--- a/src/sqlite/def/schema.rs
+++ b/src/sqlite/def/schema.rs
@@ -1,6 +1,6 @@
 use super::{IndexInfo, TableDef};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Schema {
     pub tables: Vec<TableDef>,
     pub indexes: Vec<IndexInfo>,

--- a/src/sqlite/def/table.rs
+++ b/src/sqlite/def/table.rs
@@ -13,7 +13,7 @@ use crate::sqlite::{error::DiscoveryResult, executor::Executor};
 use crate::sqlx_types::{Row, sqlite::SqliteRow};
 
 /// Defines a table for SQLite
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct TableDef {
     /// The table name
     pub name: String,


### PR DESCRIPTION
## New Features

A `PartialEq` implementation for the Sqlite schema. 
This aligns with the postgres & MySQL schemas.
