### PR TITLE
deps(cargo): upgrade `sqlx` from `0.8` to `0.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ documentation = "https://docs.rs/sea-schema"
 repository = "https://github.com/SeaQL/sea-schema"
 categories = ["database"]
 keywords = ["database", "sql", "mysql", "postgres"]
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 
 [package.metadata.docs.rs]
 features = ["default"]
@@ -40,7 +40,7 @@ sea-schema-derive = { version = "0.3.0", path = "sea-schema-derive", default-fea
 sea-query = { version = "1.0.0-rc.18", default-features = false, features = ["derive"] }
 sea-query-sqlx = { version = "0.8.0-rc.1", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
-sqlx = { version = "0.8", default-features = false, optional = true }
+sqlx = { version = "0.9", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 
 [features]
@@ -90,30 +90,43 @@ runtime-tokio = [
     "sqlx?/runtime-tokio",
     "sea-query-sqlx?/runtime-tokio",
 ]
-runtime-actix-native-tls = [
-    "sqlx?/runtime-tokio-native-tls",
-    "sea-query-sqlx?/runtime-actix-native-tls",
+tls-none = [
+    "sqlx?/tls-none",
+    "sea-query-sqlx?/tls-none"
 ]
-runtime-async-std-native-tls = [
-    "sqlx?/runtime-async-std-native-tls",
-    "sea-query-sqlx?/runtime-async-std-native-tls",
+tls-native-tls = [
+    "sqlx?/tls-native-tls",
+    "sea-query-sqlx?/tls-native-tls"
 ]
-runtime-tokio-native-tls = [
-    "sqlx?/runtime-tokio-native-tls",
-    "sea-query-sqlx?/runtime-tokio-native-tls",
+tls-rustls = [
+    "sqlx?/tls-rustls",
+    "sea-query-sqlx?/tls-rustls"
 ]
-runtime-actix-rustls = [
-    "sqlx?/runtime-tokio-rustls",
-    "sea-query-sqlx?/runtime-actix-rustls",
+tls-rustls-aws-lc-rs = [
+    "sqlx?/tls-rustls-aws-lc-rs",
+    "sea-query-sqlx?/tls-rustls-aws-lc-rs"
 ]
-runtime-async-std-rustls = [
-    "sqlx?/runtime-async-std-rustls",
-    "sea-query-sqlx?/runtime-async-std-rustls",
+tls-rustls-ring = [
+    "sqlx?/tls-rustls-ring",
+    "sea-query-sqlx?/tls-rustls-ring"
 ]
-runtime-tokio-rustls = [
-    "sqlx?/runtime-tokio-rustls",
-    "sea-query-sqlx?/runtime-tokio-rustls",
+tls-rustls-ring-native-roots = [
+    "sqlx?/tls-rustls-ring-native-roots",
+    "sea-query-sqlx?/tls-rustls-ring-native-roots"
 ]
+tls-rustls-ring-webpki = [
+    "sqlx?/tls-rustls-ring-webpki",
+    "sea-query-sqlx?/tls-rustls-ring-webpki"
+]
+
+# TODO: Remove those as a breaking change.
+runtime-actix-native-tls = ["tls-native-tls", "runtime-actix"]
+runtime-async-std-native-tls = ["tls-native-tls", "runtime-async-std"]
+runtime-tokio-native-tls = ["tls-native-tls", "runtime-tokio"]
+runtime-actix-rustls = ["tls-rustls", "runtime-actix"]
+runtime-async-std-rustls = ["tls-rustls", "runtime-async-std"]
+runtime-tokio-rustls = ["tls-rustls", "runtime-tokio"]
+
 rusqlite = []
 with-serde = ["serde"]
 

--- a/build-tools/make-sync.sh
+++ b/build-tools/make-sync.sh
@@ -18,7 +18,7 @@ find src -type f -name '*.rs' -exec sed -i '' 's/not(feature = "sqlx-sqlite")/al
 find src   -type f -name '*.rs' -exec sed -i '' 's/#\[cfg(feature = "sqlx-sqlite")\]/#\[cfg(feature = "rusqlite")\]/' {} +
 find tests -type f -name 'Cargo.toml' -exec sed -i '' 's/sea-schema/sea-schema-sync/' {} +
 find tests -type f -name 'Cargo.toml' -exec sed -i '' 's/sqlx-sqlite/rusqlite/' {} +
-find tests -type f -name 'Cargo.toml' -exec sed -i '' 's/, "runtime-async-std-native-tls"//' {} +
+find tests -type f -name 'Cargo.toml' -exec sed -i '' 's/, "runtime-async-std", "tls-native-tls",//' {} +
 find tests -type f -name 'Cargo.toml' -exec sed -i '' '/sqlx/d' {} +
 find tests -type f -name 'Cargo.toml' -exec sed -i '' '/async-std/d' {} +
 find tests -type f -name '*.rs' -exec sed -i '' '/async_std/d' {} +

--- a/sea-schema-derive/Cargo.toml
+++ b/sea-schema-derive/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/sea-schema"
 repository = "https://github.com/SeaQL/sea-schema"
 categories = [ "database" ]
 keywords = [ "database", "sql", "mysql", "postgres", "sqlite" ]
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 
 [lib]
 proc-macro = true

--- a/sea-schema-sync/Cargo.toml
+++ b/sea-schema-sync/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/sea-schema"
 repository = "https://github.com/SeaQL/sea-schema"
 categories = ["database"]
 keywords = ["database", "sql", "mysql", "postgres"]
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 
 [package.metadata.docs.rs]
 features = ["default"]

--- a/sea-schema-sync/tests/discovery/sqlite/Cargo.toml
+++ b/sea-schema-sync/tests/discovery/sqlite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sea-schema-sync-discovery-test-sqlite"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]

--- a/sea-schema-sync/tests/live/sqlite/Cargo.toml
+++ b/sea-schema-sync/tests/live/sqlite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sqlite"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sea-schema-sync/tests/writer/sqlite/Cargo.toml
+++ b/sea-schema-sync/tests/writer/sqlite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sea-schema-sync-writer-test-sqlite"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]

--- a/src/postgres/discovery/executor/real.rs
+++ b/src/postgres/discovery/executor/real.rs
@@ -1,6 +1,6 @@
 use sea_query::{PostgresQueryBuilder, SelectStatement};
 use sea_query_sqlx::SqlxBinder;
-use sqlx::PgPool;
+use sqlx::{AssertSqlSafe, PgPool};
 
 use crate::{
     Connection, debug_print,
@@ -27,7 +27,7 @@ impl Connection for Executor {
         let (sql, values) = select.build_sqlx(PostgresQueryBuilder);
         debug_print!("{}, {:?}", sql, values);
 
-        Ok(sqlx::query_with(&sql, values)
+        Ok(sqlx::query_with(AssertSqlSafe(sql), values)
             .fetch_all(&mut *self.pool.acquire().await?)
             .await?
             .into_iter()
@@ -38,7 +38,7 @@ impl Connection for Executor {
     async fn query_all_raw(&self, sql: String) -> Result<Vec<SqlxRow>, SqlxError> {
         debug_print!("{}", sql);
 
-        Ok(sqlx::query(&sql)
+        Ok(sqlx::query(AssertSqlSafe(sql))
             .fetch_all(&mut *self.pool.acquire().await?)
             .await?
             .into_iter()

--- a/tests/discovery/mysql/Cargo.toml
+++ b/tests/discovery/mysql/Cargo.toml
@@ -2,13 +2,13 @@
 name = "sea-schema-discovery-test-mysql"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-mysql", "runtime-async-std", "tls-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }
 env_logger = { version = "0" }
 log = { version = "0" }

--- a/tests/discovery/postgres/Cargo.toml
+++ b/tests/discovery/postgres/Cargo.toml
@@ -2,13 +2,13 @@
 name = "sea-schema-discovery-test-postgres"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-postgres", "runtime-async-std", "tls-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }
 env_logger = { version = "0" }
 log = { version = "0" }

--- a/tests/discovery/sqlite/Cargo.toml
+++ b/tests/discovery/sqlite/Cargo.toml
@@ -2,11 +2,11 @@
 name = "sea-schema-discovery-test-sqlite"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "with-serde", "sqlx-sqlite", "runtime-async-std", "tls-native-tls", "discovery", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }

--- a/tests/live/mysql/Cargo.toml
+++ b/tests/live/mysql/Cargo.toml
@@ -2,14 +2,14 @@
 name = "sea-schema-live-test-mysql"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std", "tls-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }
 pretty_assertions = { version = "0.7" }
 regex = { version = "1" }
 env_logger = { version = "0" }

--- a/tests/live/postgres/Cargo.toml
+++ b/tests/live/postgres/Cargo.toml
@@ -2,14 +2,14 @@
 name = "sea-schema-live-test-postgres"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std", "tls-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }
 env_logger = { version = "0" }
 log = { version = "0" }
 pretty_assertions = { version = "0.7" }

--- a/tests/live/sqlite/Cargo.toml
+++ b/tests/live/sqlite/Cargo.toml
@@ -2,14 +2,14 @@
 name = "sqlite"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
 sea-schema = { path = "../../../", default-features = false, features = [
-    "runtime-async-std-native-tls",
+    "runtime-async-std", "tls-native-tls",
     "discovery",
     "writer",
     "debug-print",
@@ -18,7 +18,7 @@ sea-schema = { path = "../../../", default-features = false, features = [
     "sqlite",
 ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8", features = ["sqlite", "runtime-async-std-native-tls"] }
+sqlx = { version = "0.9", features = ["sqlite", "runtime-async-std", "tls-native-tls"] }
 pretty_assertions = { version = "0.7" }
 env_logger = { version = "0" }
 log = { version = "0" }

--- a/tests/partially_unique_index/Cargo.toml
+++ b/tests/partially_unique_index/Cargo.toml
@@ -21,4 +21,4 @@ async-std = { version = "1.8", features = [
 postgresql_embedded = { version = "0.19", features = [
 	"blocking",
 ] }
-sqlx = "0.8"
+sqlx = "0.9"

--- a/tests/writer/mysql/Cargo.toml
+++ b/tests/writer/mysql/Cargo.toml
@@ -2,13 +2,13 @@
 name = "sea-schema-writer-test-mysql"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-mysql", "runtime-async-std", "tls-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }
 env_logger = { version = "0" }
 log = { version = "0" }

--- a/tests/writer/postgres/Cargo.toml
+++ b/tests/writer/postgres/Cargo.toml
@@ -2,14 +2,14 @@
 name = "sea-schema-writer-test-postgres"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 pretty_assertions = { version = "0.7" }
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-postgres", "runtime-async-std", "tls-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "1" }
-sqlx = { version = "0.8" }
+sqlx = { version = "0.9" }
 env_logger = { version = "0" }
 log = { version = "0" }

--- a/tests/writer/sqlite/Cargo.toml
+++ b/tests/writer/sqlite/Cargo.toml
@@ -2,10 +2,10 @@
 name = "sea-schema-writer-test-sqlite"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes", "tokio1" ] }
-sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-sqlite", "runtime-async-std-native-tls", "discovery", "writer", "debug-print" ] }
+sea-schema = { path = "../../../", default-features = false, features = [ "sqlx-sqlite", "runtime-async-std", "tls-native-tls", "discovery", "writer", "debug-print" ] }
 serde_json = { version = "1" }


### PR DESCRIPTION
`sqlx` had a breaking change in its cargo build features that is ported to `sea-schema` in a compatible way. Old features should be documented as deprecated in the next release's changelog.

As per `sqlx`'s [MSRV policy](https://github.com/launchbadge/sqlx/blob/75bc0487eb661da811bb7a3c5d158f1bd463fef4/FAQ.md#MSRV), the supported Rust version is [1.94.0](https://doc.rust-lang.org/stable/releases.html#version-1940-2026-03-05).

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - https://github.com/SeaQL/sea-query/pull/1075

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/3065

## New Features

<!-- - [ ] what are the new features? -->

## Bug Fixes

<!-- - [ ] if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

<!-- - [ ] any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] Upgrade `sqlx` to `0.9`
- [x] New `tls-*` cargo features were exposed from `sqlx`.
