### PR TITLE
Postgres: fix composite foreign key discovery emitting duplicated columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Postgres fix enum discovery to be schema-specific https://github.com/SeaQL/sea-schema/pull/156
 * Postgres fix foreign key discovery to be schema-specific https://github.com/SeaQL/sea-schema/pull/157
 * Postgres fix foreign key discovery where components may have duplicate columns
+* Postgres fix composite foreign key discovery emitting duplicated columns when referencing a bare unique index https://github.com/SeaQL/sea-orm/issues/2662
 * Postgres fix unique key discovery where components have wrong orders
 
 ## 0.16.2 - 2025-05-07

--- a/sea-schema-sync/src/postgres/parser/table_constraints.rs
+++ b/sea-schema-sync/src/postgres/parser/table_constraints.rs
@@ -60,8 +60,8 @@ pub fn parse_table_constraint_query_results(
                     }
                 }
 
-                columns.dedup();
-                foreign_columns.dedup();
+                dedup_preserving_order(&mut columns);
+                dedup_preserving_order(&mut foreign_columns);
 
                 output.push(Constraint::References(References {
                     name: constraint_name,
@@ -117,4 +117,86 @@ pub fn parse_table_constraint_query_results(
     }
 
     output
+}
+
+/// Remove duplicated values in-place while preserving first-seen order.
+///
+/// A well-formed key never repeats a column, so this is a no-op for valid
+/// input. It only repairs the degenerate case where schema discovery cannot
+/// correlate a composite foreign key's columns with the referenced columns:
+/// when the key references a bare `UNIQUE INDEX` rather than a named `UNIQUE` /
+/// `PRIMARY KEY` constraint, Postgres' `information_schema` does not expose the
+/// referenced constraint, so `query_table_constraints` falls back to the
+/// cartesian product of the local and referenced column lists. `Vec::dedup`
+/// would only collapse *consecutive* duplicates, leaving interleaved
+/// repetitions such as `[a, b, a, b]` untouched.
+fn dedup_preserving_order(columns: &mut Vec<String>) {
+    let mut seen = std::collections::HashSet::new();
+    columns.retain(|column| seen.insert(column.clone()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn foreign_key_row(column: &str, referenced: &str) -> TableConstraintsQueryResult {
+        TableConstraintsQueryResult {
+            constraint_name: "fk_pair".to_owned(),
+            constraint_type: "FOREIGN KEY".to_owned(),
+            column_name: Some(column.to_owned()),
+            referential_key_table_name: Some("parent".to_owned()),
+            referential_key_column_name: Some(referenced.to_owned()),
+            update_rule: Some("NO ACTION".to_owned()),
+            delete_rule: Some("CASCADE".to_owned()),
+            ..Default::default()
+        }
+    }
+
+    /// When a composite foreign key references a bare `UNIQUE INDEX` rather than
+    /// a named constraint, `information_schema` cannot correlate the local and
+    /// referenced columns, so the discovery query returns their cartesian
+    /// product. It is ordered by the local column's ordinal position only,
+    /// which interleaves the referenced columns as `[left, right, left, right]`.
+    /// The parser must collapse this back to the intended 1:1 column pairing
+    /// rather than emitting duplicated columns. See SeaQL/sea-orm#2662.
+    #[test]
+    fn dedups_cartesian_product_for_composite_foreign_key() {
+        let results = vec![
+            foreign_key_row("left", "left"),
+            foreign_key_row("left", "right"),
+            foreign_key_row("right", "left"),
+            foreign_key_row("right", "right"),
+        ];
+
+        assert_eq!(
+            parse_table_constraint_query_results(results),
+            vec![Constraint::References(References {
+                name: "fk_pair".to_owned(),
+                columns: vec!["left".to_owned(), "right".to_owned()],
+                table: "parent".to_owned(),
+                foreign_columns: vec!["left".to_owned(), "right".to_owned()],
+                on_update: Some(ForeignKeyAction::NoAction),
+                on_delete: Some(ForeignKeyAction::Cascade),
+            })]
+        );
+    }
+
+    /// A well-formed composite foreign key (no duplicated columns) is preserved
+    /// verbatim, including the local-to-referenced column pairing.
+    #[test]
+    fn keeps_well_formed_composite_foreign_key() {
+        let results = vec![foreign_key_row("f_a", "a"), foreign_key_row("f_b", "b")];
+
+        assert_eq!(
+            parse_table_constraint_query_results(results),
+            vec![Constraint::References(References {
+                name: "fk_pair".to_owned(),
+                columns: vec!["f_a".to_owned(), "f_b".to_owned()],
+                table: "parent".to_owned(),
+                foreign_columns: vec!["a".to_owned(), "b".to_owned()],
+                on_update: Some(ForeignKeyAction::NoAction),
+                on_delete: Some(ForeignKeyAction::Cascade),
+            })]
+        );
+    }
 }

--- a/src/postgres/parser/table_constraints.rs
+++ b/src/postgres/parser/table_constraints.rs
@@ -60,8 +60,8 @@ pub fn parse_table_constraint_query_results(
                     }
                 }
 
-                columns.dedup();
-                foreign_columns.dedup();
+                dedup_preserving_order(&mut columns);
+                dedup_preserving_order(&mut foreign_columns);
 
                 output.push(Constraint::References(References {
                     name: constraint_name,
@@ -117,4 +117,86 @@ pub fn parse_table_constraint_query_results(
     }
 
     output
+}
+
+/// Remove duplicated values in-place while preserving first-seen order.
+///
+/// A well-formed key never repeats a column, so this is a no-op for valid
+/// input. It only repairs the degenerate case where schema discovery cannot
+/// correlate a composite foreign key's columns with the referenced columns:
+/// when the key references a bare `UNIQUE INDEX` rather than a named `UNIQUE` /
+/// `PRIMARY KEY` constraint, Postgres' `information_schema` does not expose the
+/// referenced constraint, so `query_table_constraints` falls back to the
+/// cartesian product of the local and referenced column lists. `Vec::dedup`
+/// would only collapse *consecutive* duplicates, leaving interleaved
+/// repetitions such as `[a, b, a, b]` untouched.
+fn dedup_preserving_order(columns: &mut Vec<String>) {
+    let mut seen = std::collections::HashSet::new();
+    columns.retain(|column| seen.insert(column.clone()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn foreign_key_row(column: &str, referenced: &str) -> TableConstraintsQueryResult {
+        TableConstraintsQueryResult {
+            constraint_name: "fk_pair".to_owned(),
+            constraint_type: "FOREIGN KEY".to_owned(),
+            column_name: Some(column.to_owned()),
+            referential_key_table_name: Some("parent".to_owned()),
+            referential_key_column_name: Some(referenced.to_owned()),
+            update_rule: Some("NO ACTION".to_owned()),
+            delete_rule: Some("CASCADE".to_owned()),
+            ..Default::default()
+        }
+    }
+
+    /// When a composite foreign key references a bare `UNIQUE INDEX` rather than
+    /// a named constraint, `information_schema` cannot correlate the local and
+    /// referenced columns, so the discovery query returns their cartesian
+    /// product. It is ordered by the local column's ordinal position only,
+    /// which interleaves the referenced columns as `[left, right, left, right]`.
+    /// The parser must collapse this back to the intended 1:1 column pairing
+    /// rather than emitting duplicated columns. See SeaQL/sea-orm#2662.
+    #[test]
+    fn dedups_cartesian_product_for_composite_foreign_key() {
+        let results = vec![
+            foreign_key_row("left", "left"),
+            foreign_key_row("left", "right"),
+            foreign_key_row("right", "left"),
+            foreign_key_row("right", "right"),
+        ];
+
+        assert_eq!(
+            parse_table_constraint_query_results(results),
+            vec![Constraint::References(References {
+                name: "fk_pair".to_owned(),
+                columns: vec!["left".to_owned(), "right".to_owned()],
+                table: "parent".to_owned(),
+                foreign_columns: vec!["left".to_owned(), "right".to_owned()],
+                on_update: Some(ForeignKeyAction::NoAction),
+                on_delete: Some(ForeignKeyAction::Cascade),
+            })]
+        );
+    }
+
+    /// A well-formed composite foreign key (no duplicated columns) is preserved
+    /// verbatim, including the local-to-referenced column pairing.
+    #[test]
+    fn keeps_well_formed_composite_foreign_key() {
+        let results = vec![foreign_key_row("f_a", "a"), foreign_key_row("f_b", "b")];
+
+        assert_eq!(
+            parse_table_constraint_query_results(results),
+            vec![Constraint::References(References {
+                name: "fk_pair".to_owned(),
+                columns: vec!["f_a".to_owned(), "f_b".to_owned()],
+                table: "parent".to_owned(),
+                foreign_columns: vec!["a".to_owned(), "b".to_owned()],
+                on_update: Some(ForeignKeyAction::NoAction),
+                on_delete: Some(ForeignKeyAction::Cascade),
+            })]
+        );
+    }
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/2662
- Dependencies:
  - N/A
- Dependents:
  - N/A

  > The same root cause was worked around defensively on the codegen side in https://github.com/SeaQL/sea-orm/pull/3096. This PR fixes it at the source, so that codegen-side change becomes unnecessary once a `sea-schema` release containing this fix is picked up by `sea-orm`.

## New Features

- N/A

## Bug Fixes

- [x] **Composite foreign keys that reference a bare unique index were discovered with duplicated columns.**

  When a composite FK targets a bare unique index (`CREATE UNIQUE INDEX …`) rather than a named `UNIQUE` / `PRIMARY KEY` constraint, PostgreSQL's `information_schema` does not expose the referenced constraint, so `query_table_constraints` cannot correlate the local and referenced columns by ordinal position and falls back to their **cartesian product** — local `[left, right]` paired with referenced `[left, right]` returns four rows instead of two.

  The earlier fix (5aa325a) de-duplicated both column lists with `Vec::dedup`, but `Vec::dedup` only removes *consecutive* duplicates:

  - the local side comes back **grouped** as `[left, left, right, right]` → collapses correctly to `[left, right]`;
  - the referenced side comes back **interleaved** as `[left, right, left, right]` → left untouched.

  So the two lists ended up with mismatched lengths and the referenced columns stayed duplicated. Downstream this surfaced as `sea-orm-cli generate entity` producing a malformed relation, e.g. `from = "(Column::Left, Column::Right)", to = "(…::Left, …::Right, …::Left, …::Right)"`, whose generated join `ON` clause matches no rows.

  Fixed by replacing `Vec::dedup` with an order-preserving, full de-duplication on both lists, so both the grouped and the interleaved shapes collapse to the intended 1:1 column pairing.

## Breaking Changes

- [ ] None — backward compatible. A well-formed foreign key never repeats a column on either side, so the de-duplication is a no-op for valid input; only the previously-malformed (cartesian-product) output changes, so existing correct schemas re-discover identically.

## Changes

- [x] Replace `Vec::dedup` with an order-preserving `dedup_preserving_order` for the local and referenced column lists in the Postgres table-constraints parser (`src/postgres/parser/table_constraints.rs`, and the mirrored `sea-schema-sync` copy).
- [x] Add deterministic unit tests covering the interleaved cartesian-product case (which the previous `Vec::dedup` did not collapse) and the well-formed composite-FK case.
- [x] Add a `CHANGELOG` entry.
