### PR TITLE
Make Connection futures Send under sqlx backends (fixes SeaORM #3100)

### DIFF
--- a/build-tools/make-sync.sh
+++ b/build-tools/make-sync.sh
@@ -29,6 +29,6 @@ find src -type f -name '*.rs' -exec sed -i '' "s/SqlxRow/RusqliteRow/g" {} +
 find src -type f -name '*.rs' -exec sed -i '' 's/SqlxError/RusqliteError/g' {} +
 find src -type f -name '*.rs' -exec sed -i '' 's/SQLx/Rusqlite/' {} +
 find src -type f -name '*.rs' -exec sed -i '' 's/SqlitePool/RusqliteConnection/' {} +
-find src -type f -name '*.rs' -exec sed -i '' '/#\[async_trait::async_trait/d' {} +
+find src -type f -name '*.rs' -exec sed -i '' '/async_trait::async_trait/d' {} +
 find src -type f -name '*.rs' -exec sed -i '' 's/ \+ Sync//' {} +
 cargo fmt

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,8 @@
 use crate::sqlx_types::{SqlxError, SqlxRow};
 use sea_query::SelectStatement;
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 pub trait Connection: Sized + Sync {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError>;
 

--- a/src/mysql/discovery/executor/mock.rs
+++ b/src/mysql/discovery/executor/mock.rs
@@ -19,7 +19,8 @@ impl IntoExecutor for MySqlPool {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         let (_sql, _values) = select.build(MysqlQueryBuilder);

--- a/src/mysql/discovery/executor/real.rs
+++ b/src/mysql/discovery/executor/real.rs
@@ -38,7 +38,8 @@ impl GetMySqlValue for MySqlRow {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         let (sql, values) = select.build_sqlx(MysqlQueryBuilder);

--- a/src/postgres/discovery/executor/mock.rs
+++ b/src/postgres/discovery/executor/mock.rs
@@ -19,7 +19,8 @@ impl IntoExecutor for PgPool {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         let (_sql, _values) = select.build(PostgresQueryBuilder);

--- a/src/postgres/discovery/executor/real.rs
+++ b/src/postgres/discovery/executor/real.rs
@@ -21,7 +21,8 @@ impl IntoExecutor for PgPool {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         let (sql, values) = select.build_sqlx(PostgresQueryBuilder);

--- a/src/sqlite/executor/mock.rs
+++ b/src/sqlite/executor/mock.rs
@@ -19,7 +19,8 @@ impl IntoExecutor for SqlitePool {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         let (_sql, _values) = select.build(SqliteQueryBuilder);

--- a/src/sqlite/executor/real.rs
+++ b/src/sqlite/executor/real.rs
@@ -21,7 +21,8 @@ impl IntoExecutor for SqlitePool {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     async fn query_all(&self, select: SelectStatement) -> Result<Vec<SqlxRow>, SqlxError> {
         let (sql, values) = select.build_sqlx(SqliteQueryBuilder);

--- a/src/sqlite/executor/rusqlite.rs
+++ b/src/sqlite/executor/rusqlite.rs
@@ -17,7 +17,8 @@ impl IntoExecutor for RusqliteConnection {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[cfg_attr(feature = "sqlx-dep", async_trait::async_trait)]
+#[cfg_attr(not(feature = "sqlx-dep"), async_trait::async_trait(?Send))]
 impl Connection for Executor {
     fn query_all(&self, select: SelectStatement) -> Result<Vec<RusqliteRow>, RusqliteError> {
         let (sql, values) = select.build_rusqlite(SqliteQueryBuilder);


### PR DESCRIPTION
Fixes the SeaORM #3100 regression: `SchemaBuilder::sync()` returns a non-`Send` future in RC41, unusable from multi-threaded async runtimes.

## Cause
sea-schema 0.18 declared the `Connection` trait with `#[async_trait::async_trait(?Send)]`, stripping the `Send` bound from every discovery future. That propagated all the way out to SeaORM's `sync()`.

## Fix
Gate the `Send` bound on the `sqlx-dep` feature:
- **sqlx backends** pull in sea-query `thread-safe` (so `SelectStatement: Send`) and produce `Send` futures → trait uses `#[async_trait]`.
- The blocking **rusqlite / mock** path (sea-query not thread-safe, `SelectStatement: !Send`) stays `#[async_trait(?Send)]`.

Applied uniformly to `connection.rs` and all executor impls so trait + impls stay consistent per feature combo.

`build-tools/make-sync.sh`: broadened the async_trait strip so it also removes the `cfg_attr`-wrapped form when generating the blocking `sea-schema-sync` crate.

## Verified locally
- Builds: default (mock, `?Send`), sqlx-sqlite (+mysql/postgres mocks under `Send`), `sea-schema-sync` regenerated + builds.
- SeaORM `SchemaBuilder::sync()` future is `Send` again (compile-guard passes) when built against this branch.