### PR TITLE
- Add support for MySQL views scanning.

### DIFF
--- a/src/mysql/parser/table.rs
+++ b/src/mysql/parser/table.rs
@@ -11,7 +11,7 @@ impl TableQueryResult {
 pub fn parse_table_query_result(result: TableQueryResult) -> TableInfo {
     TableInfo {
         name: result.table_name,
-        engine: StorageEngine::from_str(result.engine.as_str()).unwrap(),
+        engine: StorageEngine::from_str(result.engine.unwrap_or_default().as_str()).unwrap(),
         auto_increment: result.auto_increment,
         char_set: result.table_char_set.as_deref().and_then(CharSet::from_str),
         collation: result

--- a/src/mysql/query/table.rs
+++ b/src/mysql/query/table.rs
@@ -47,12 +47,12 @@ pub enum TableType {
 #[derive(Debug, Default)]
 pub struct TableQueryResult {
     pub table_name: String,
-    pub engine: String,
+    pub engine: Option<String>,
     pub auto_increment: Option<u64>,
     pub table_char_set: Option<String>,
     pub table_collation: Option<String>,
     pub table_comment: String,
-    pub create_options: String,
+    pub create_options: Option<String>,
 }
 
 impl SchemaQueryBuilder {
@@ -96,6 +96,7 @@ impl SchemaQueryBuilder {
             .and_where(Expr::col(TablesFields::TableSchema).eq(schema.to_string()))
             .and_where(Expr::col(TablesFields::TableType).is_in([
                 TableType::BaseTable.to_string(),
+                TableType::View.to_string(),
                 TableType::SystemVersioned.to_string(),
             ]))
             .order_by(TablesFields::TableName, Order::Asc)
@@ -111,11 +112,11 @@ impl From<SqlxRow> for TableQueryResult {
         let row = row.mysql();
         Self {
             table_name: row.get_string(0),
-            engine: row.get_string(1),
+            engine: row.get_string_opt(1),
             auto_increment: row.get(2),
             table_collation: row.get_string_opt(3),
             table_comment: row.get_string(4),
-            create_options: row.get_string(5),
+            create_options: row.get_string_opt(5),
             table_char_set: row.get_string_opt(6),
         }
     }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-schema/issues/58

## New Features

- [ ] Add support for MySQL views scanning.

## Breaking Changes

- [ ] Changed  `mysql::query::table::TableQueryResult` fields: made `engine` and `create_options` optional.
